### PR TITLE
Phase 2: Model management with HF Hub and downloads

### DIFF
--- a/HearthAI.xcodeproj/project.pbxproj
+++ b/HearthAI.xcodeproj/project.pbxproj
@@ -9,8 +9,12 @@
 /* Begin PBXBuildFile section */
 		01C5AA9BD6F4C0823A324194 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D68E1B22F6633BA12A90545 /* SettingsView.swift */; };
 		03A3AF701474977398790AA6 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5163E146981BFA10057E46 /* ChatView.swift */; };
+		08254E655C4E1BF9388FCC6A /* ModelStoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA0F0505A852036347ADD6 /* ModelStoreViewModel.swift */; };
 		0BE4B41958A063A6C03F361B /* LocalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE68C23BD50C2CE6816C8530 /* LocalModel.swift */; };
+		155F299FF7740D656A56B321 /* FeaturedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373240DBA631EE03834240EE /* FeaturedModel.swift */; };
 		17C2529672146A86D835ACAB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405D1CA44865EBE10F089668 /* ContentView.swift */; };
+		277EC11BB99B21DB654150CC /* FeaturedModels.json in Resources */ = {isa = PBXBuildFile; fileRef = 7FA5D99754391A1FBEBEECBE /* FeaturedModels.json */; };
+		2E72E749941AF06D4AE14798 /* HFModelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9CB851129C2E57E58FF870 /* HFModelInfo.swift */; };
 		34D96B95583163C41CC83B2D /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E25E2D8EA8D4E4C2937D929 /* PreviewData.swift */; };
 		3EC1B05C4AAF3F0C5AC05A30 /* ThermalMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C3075948717C3F9278DAD5 /* ThermalMonitor.swift */; };
 		3ECF7975DBD75B903E5EB857 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005D99CFD00EACE9FC742BC6 /* Message.swift */; };
@@ -20,13 +24,20 @@
 		80380C505B03C4BF206F41EB /* LlamaCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 245B624756E2589153690CEC /* LlamaCpp */; };
 		80B7CA2CFD0017FD15878CE4 /* ModelStoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315875C2BEE8F04B1653AEA1 /* ModelStoreView.swift */; };
 		8747ADDE6914933ED42C70A5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B5F72E3F69C00CEDE45E8C /* Constants.swift */; };
+		8A78CB0370790965C3B33F2D /* HuggingFaceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A6F0DD2CF3C5F44E0C0190 /* HuggingFaceAPI.swift */; };
+		94D339C97159BD1FE1910F02 /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276338C3C40E6E21B3AF5F5 /* DownloadState.swift */; };
 		988A1466A3BB010F3686F065 /* HearthAIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E903921FAA09285C7EC06626 /* HearthAIApp.swift */; };
+		A63768214BABE2B98203900A /* FeaturedModelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C845EBC43D03C4AAB4C3E312 /* FeaturedModelDetailView.swift */; };
 		A6E9B6197D48DAC4014311FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1EA4C3783A128CC1C2D30817 /* Assets.xcassets */; };
+		A8F8386F0CC30F0FDEB0FA60 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9160C707541C1A6967F91F9 /* ModelPickerSheet.swift */; };
+		B978D5031CC9F31BB9590F6B /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46AE8CED565F05123B55EE96 /* LibraryView.swift */; };
 		C7F2A3D0417981686B4E3052 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397BD3F6A93E6069059BBBBF /* AppState.swift */; };
+		CDB4579A512B12F942C6E768 /* ModelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */; };
 		F09B9F855596430552F5A8FE /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890BDB102F2FE40261F5A508 /* ChatViewModel.swift */; };
 		F1AD3F2C8048B14FC787BF4D /* FileManager+AppSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7FB411EA3CC770171848E7 /* FileManager+AppSupport.swift */; };
 		F6D7E75B6E97C47D01634F4B /* InferenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D431ED0C8BB31AC0B5AA80D /* InferenceService.swift */; };
 		FDF5740963252281A3030A24 /* HearthAITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29482A421FB1811401D6034E /* HearthAITests.swift */; };
+		FF28A34B4C8D7ACEBC31AEBA /* DownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9017344B1655F30D083ABC /* DownloadService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,20 +53,31 @@
 /* Begin PBXFileReference section */
 		005D99CFD00EACE9FC742BC6 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		0D431ED0C8BB31AC0B5AA80D /* InferenceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceService.swift; sourceTree = "<group>"; };
+		1276338C3C40E6E21B3AF5F5 /* DownloadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadState.swift; sourceTree = "<group>"; };
 		1E25E2D8EA8D4E4C2937D929 /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
 		1EA4C3783A128CC1C2D30817 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		23FA0F0505A852036347ADD6 /* ModelStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelStoreViewModel.swift; sourceTree = "<group>"; };
 		29482A421FB1811401D6034E /* HearthAITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HearthAITests.swift; sourceTree = "<group>"; };
 		315875C2BEE8F04B1653AEA1 /* ModelStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelStoreView.swift; sourceTree = "<group>"; };
+		31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailView.swift; sourceTree = "<group>"; };
 		3308EA296BE9611CEE76B736 /* HearthAITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HearthAITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		373240DBA631EE03834240EE /* FeaturedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedModel.swift; sourceTree = "<group>"; };
 		397BD3F6A93E6069059BBBBF /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		405D1CA44865EBE10F089668 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		46AE8CED565F05123B55EE96 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		4B9017344B1655F30D083ABC /* DownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadService.swift; sourceTree = "<group>"; };
 		4D21045F4D81AD9F0E6874C6 /* LlamaCpp */ = {isa = PBXFileReference; lastKnownFileType = folder; name = LlamaCpp; path = Packages/LlamaCpp; sourceTree = SOURCE_ROOT; };
+		4D9CB851129C2E57E58FF870 /* HFModelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HFModelInfo.swift; sourceTree = "<group>"; };
 		5D1D6195ED7695130A8D335C /* HearthAI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HearthAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E60EC72A2F0D58CA567D91D /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
+		7FA5D99754391A1FBEBEECBE /* FeaturedModels.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FeaturedModels.json; sourceTree = "<group>"; };
 		890BDB102F2FE40261F5A508 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		8D68E1B22F6633BA12A90545 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		99C3075948717C3F9278DAD5 /* ThermalMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalMonitor.swift; sourceTree = "<group>"; };
+		B1A6F0DD2CF3C5F44E0C0190 /* HuggingFaceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPI.swift; sourceTree = "<group>"; };
 		B6B5F72E3F69C00CEDE45E8C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		C845EBC43D03C4AAB4C3E312 /* FeaturedModelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedModelDetailView.swift; sourceTree = "<group>"; };
+		C9160C707541C1A6967F91F9 /* ModelPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPickerSheet.swift; sourceTree = "<group>"; };
 		C988D7AB8665E8A6DFE87363 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		CD7FB411EA3CC770171848E7 /* FileManager+AppSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+AppSupport.swift"; sourceTree = "<group>"; };
 		CE68C23BD50C2CE6816C8530 /* LocalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModel.swift; sourceTree = "<group>"; };
@@ -88,6 +110,7 @@
 		17BC82A6EC84F776D1F486C6 /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				46AE8CED565F05123B55EE96 /* LibraryView.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -122,6 +145,9 @@
 		2F0C272745E1A7BF756F96A4 /* HuggingFace */ = {
 			isa = PBXGroup;
 			children = (
+				373240DBA631EE03834240EE /* FeaturedModel.swift */,
+				4D9CB851129C2E57E58FF870 /* HFModelInfo.swift */,
+				B1A6F0DD2CF3C5F44E0C0190 /* HuggingFaceAPI.swift */,
 			);
 			path = HuggingFace;
 			sourceTree = "<group>";
@@ -132,6 +158,7 @@
 				EA5163E146981BFA10057E46 /* ChatView.swift */,
 				890BDB102F2FE40261F5A508 /* ChatViewModel.swift */,
 				C988D7AB8665E8A6DFE87363 /* MessageBubble.swift */,
+				C9160C707541C1A6967F91F9 /* ModelPickerSheet.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -139,6 +166,8 @@
 		3F2C674A23C0DC92FA53DF35 /* Download */ = {
 			isa = PBXGroup;
 			children = (
+				4B9017344B1655F30D083ABC /* DownloadService.swift */,
+				1276338C3C40E6E21B3AF5F5 /* DownloadState.swift */,
 			);
 			path = Download;
 			sourceTree = "<group>";
@@ -202,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				1EA4C3783A128CC1C2D30817 /* Assets.xcassets */,
+				7FA5D99754391A1FBEBEECBE /* FeaturedModels.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -223,7 +253,10 @@
 		C3CEF0A248931D5C41290483 /* ModelStore */ = {
 			isa = PBXGroup;
 			children = (
+				C845EBC43D03C4AAB4C3E312 /* FeaturedModelDetailView.swift */,
+				31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */,
 				315875C2BEE8F04B1653AEA1 /* ModelStoreView.swift */,
+				23FA0F0505A852036347ADD6 /* ModelStoreViewModel.swift */,
 			);
 			path = ModelStore;
 			sourceTree = "<group>";
@@ -359,6 +392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A6E9B6197D48DAC4014311FB /* Assets.xcassets in Resources */,
+				277EC11BB99B21DB654150CC /* FeaturedModels.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -375,14 +409,24 @@
 				8747ADDE6914933ED42C70A5 /* Constants.swift in Sources */,
 				17C2529672146A86D835ACAB /* ContentView.swift in Sources */,
 				7651BC5F24C30D0D44C48067 /* Conversation.swift in Sources */,
+				FF28A34B4C8D7ACEBC31AEBA /* DownloadService.swift in Sources */,
+				94D339C97159BD1FE1910F02 /* DownloadState.swift in Sources */,
+				155F299FF7740D656A56B321 /* FeaturedModel.swift in Sources */,
+				A63768214BABE2B98203900A /* FeaturedModelDetailView.swift in Sources */,
 				F1AD3F2C8048B14FC787BF4D /* FileManager+AppSupport.swift in Sources */,
+				2E72E749941AF06D4AE14798 /* HFModelInfo.swift in Sources */,
 				988A1466A3BB010F3686F065 /* HearthAIApp.swift in Sources */,
+				8A78CB0370790965C3B33F2D /* HuggingFaceAPI.swift in Sources */,
 				78CA7BCF236B2498F77B7031 /* InferenceConfiguration.swift in Sources */,
 				F6D7E75B6E97C47D01634F4B /* InferenceService.swift in Sources */,
+				B978D5031CC9F31BB9590F6B /* LibraryView.swift in Sources */,
 				0BE4B41958A063A6C03F361B /* LocalModel.swift in Sources */,
 				3ECF7975DBD75B903E5EB857 /* Message.swift in Sources */,
 				73CE4807A74F2AD7AC5B03A0 /* MessageBubble.swift in Sources */,
+				CDB4579A512B12F942C6E768 /* ModelDetailView.swift in Sources */,
+				A8F8386F0CC30F0FDEB0FA60 /* ModelPickerSheet.swift in Sources */,
 				80B7CA2CFD0017FD15878CE4 /* ModelStoreView.swift in Sources */,
+				08254E655C4E1BF9388FCC6A /* ModelStoreViewModel.swift in Sources */,
 				34D96B95583163C41CC83B2D /* PreviewData.swift in Sources */,
 				01C5AA9BD6F4C0823A324194 /* SettingsView.swift in Sources */,
 				3EC1B05C4AAF3F0C5AC05A30 /* ThermalMonitor.swift in Sources */,

--- a/HearthAI/App/AppState.swift
+++ b/HearthAI/App/AppState.swift
@@ -5,4 +5,5 @@ import SwiftUI
 final class AppState {
     let inferenceService = InferenceService()
     let thermalMonitor = ThermalMonitor()
+    let downloadService = DownloadService()
 }

--- a/HearthAI/App/ContentView.swift
+++ b/HearthAI/App/ContentView.swift
@@ -9,6 +9,9 @@ struct ContentView: View {
             ModelStoreView()
                 .tabItem { Label("Models", systemImage: "square.grid.2x2") }
 
+            LibraryView()
+                .tabItem { Label("Library", systemImage: "internaldrive") }
+
             SettingsView()
                 .tabItem { Label("Settings", systemImage: "gear") }
         }
@@ -19,4 +22,5 @@ struct ContentView: View {
     ContentView()
         .environment(AppState())
         .environment(InferenceService())
+        .environment(DownloadService())
 }

--- a/HearthAI/App/HearthAIApp.swift
+++ b/HearthAI/App/HearthAIApp.swift
@@ -10,11 +10,64 @@ struct HearthAIApp: App {
             ContentView()
                 .environment(appState)
                 .environment(appState.inferenceService)
+                .environment(appState.downloadService)
+                .onAppear {
+                    setupDownloadCompletion()
+                }
         }
         .modelContainer(for: [
             LocalModel.self,
             Conversation.self,
             Message.self,
         ])
+    }
+
+    private func setupDownloadCompletion() {
+        appState.downloadService.onDownloadComplete = { [appState] info in
+            saveDownloadedModel(info: info, appState: appState)
+        }
+    }
+
+    @MainActor
+    private func saveDownloadedModel(info: DownloadInfo, appState: AppState) {
+        guard let container = try? ModelContainer(for: LocalModel.self) else { return }
+        let context = container.mainContext
+
+        let repoComponent = info.repoId.replacingOccurrences(of: "/", with: "_")
+        let localPath = "\(repoComponent)/\(info.fileName)"
+
+        let model = LocalModel(
+            id: info.id,
+            repoId: info.repoId,
+            fileName: info.fileName,
+            displayName: info.fileName
+                .replacingOccurrences(of: ".gguf", with: "")
+                .replacingOccurrences(of: "-", with: " ")
+                .replacingOccurrences(of: "_", with: " "),
+            modelFamily: guessModelFamily(info.repoId),
+            quantization: guessQuantization(info.fileName),
+            fileSizeBytes: info.fileSize,
+            localPath: localPath
+        )
+
+        context.insert(model)
+        try? context.save()
+    }
+
+    private func guessModelFamily(_ repoId: String) -> String {
+        let name = repoId.lowercased()
+        let families = ["llama", "mistral", "phi", "qwen", "gemma", "smollm", "tinyllama"]
+        return families.first { name.contains($0) }?.capitalized ?? "Unknown"
+    }
+
+    private func guessQuantization(_ fileName: String) -> String {
+        let name = fileName.lowercased()
+        let quants = [
+            "q2_k", "q3_k_s", "q3_k_m", "q3_k_l",
+            "q4_0", "q4_1", "q4_k_s", "q4_k_m",
+            "q5_0", "q5_1", "q5_k_s", "q5_k_m",
+            "q6_k", "q8_0", "f16", "f32",
+        ]
+        return quants.first { name.contains($0) }?.uppercased() ?? "Unknown"
     }
 }

--- a/HearthAI/Features/Chat/ChatView.swift
+++ b/HearthAI/Features/Chat/ChatView.swift
@@ -5,6 +5,7 @@ struct ChatView: View {
     @Environment(AppState.self) private var appState
     @State private var viewModel = ChatViewModel()
     @State private var inputText = ""
+    @State private var showModelPicker = false
 
     var body: some View {
         NavigationStack {
@@ -18,6 +19,20 @@ struct ChatView: View {
             .navigationTitle("Hearth AI")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showModelPicker = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "brain")
+                            if inferenceService.isModelLoaded {
+                                Circle()
+                                    .fill(.green)
+                                    .frame(width: 6, height: 6)
+                            }
+                        }
+                    }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         viewModel.clearMessages()
@@ -26,6 +41,9 @@ struct ChatView: View {
                     }
                     .disabled(viewModel.messages.isEmpty)
                 }
+            }
+            .sheet(isPresented: $showModelPicker) {
+                ModelPickerSheet()
             }
         }
         .onAppear {

--- a/HearthAI/Features/Chat/ModelPickerSheet.swift
+++ b/HearthAI/Features/Chat/ModelPickerSheet.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import SwiftData
+
+struct ModelPickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(InferenceService.self) private var inferenceService
+    @Query(sort: \LocalModel.downloadedAt, order: .reverse) private var models: [LocalModel]
+    @State private var loadError: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if models.isEmpty {
+                    ContentUnavailableView(
+                        "No Models",
+                        systemImage: "square.stack.3d.up.slash",
+                        description: Text("Download a model from the Models tab first.")
+                    )
+                } else {
+                    List(models) { model in
+                        Button {
+                            loadModel(model)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(model.displayName)
+                                        .font(.headline)
+                                    HStack(spacing: 8) {
+                                        Text(model.quantization)
+                                        Text(ByteCountFormatter.string(
+                                            fromByteCount: model.fileSizeBytes,
+                                            countStyle: .file
+                                        ))
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                if inferenceService.loadedModelId == model.id {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                } else if inferenceService.isLoading {
+                                    ProgressView()
+                                }
+                            }
+                        }
+                        .disabled(inferenceService.isLoading)
+                    }
+                }
+            }
+            .navigationTitle("Select Model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+                if inferenceService.isModelLoaded {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Unload") {
+                            Task { await inferenceService.unloadModel() }
+                        }
+                    }
+                }
+            }
+            .alert("Load Error", isPresented: .init(
+                get: { loadError != nil },
+                set: { if !$0 { loadError = nil } }
+            )) {
+                Button("OK") { loadError = nil }
+            } message: {
+                Text(loadError ?? "")
+            }
+        }
+    }
+
+    private func loadModel(_ model: LocalModel) {
+        Task {
+            do {
+                try await inferenceService.loadModel(model)
+                dismiss()
+            } catch {
+                loadError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/HearthAI/Features/Library/LibraryView.swift
+++ b/HearthAI/Features/Library/LibraryView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import SwiftData
+
+struct LibraryView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(InferenceService.self) private var inferenceService
+    @Query(sort: \LocalModel.downloadedAt, order: .reverse) private var models: [LocalModel]
+    @State private var modelToDelete: LocalModel?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if models.isEmpty {
+                    emptyState
+                } else {
+                    modelList
+                }
+            }
+            .navigationTitle("Library")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    storageInfo
+                }
+            }
+            .alert("Delete Model?", isPresented: .init(
+                get: { modelToDelete != nil },
+                set: { if !$0 { modelToDelete = nil } }
+            )) {
+                Button("Cancel", role: .cancel) { modelToDelete = nil }
+                Button("Delete", role: .destructive) {
+                    if let model = modelToDelete {
+                        deleteModel(model)
+                    }
+                }
+            } message: {
+                if let model = modelToDelete {
+                    let size = ByteCountFormatter.string(
+                        fromByteCount: model.fileSizeBytes, countStyle: .file
+                    )
+                    Text("This will delete \(model.displayName) (\(size)) from your device.")
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Models",
+            systemImage: "square.stack.3d.up.slash",
+            description: Text("Download models from the Models tab to get started.")
+        )
+    }
+
+    // MARK: - Model List
+
+    private var modelList: some View {
+        List {
+            Section {
+                ForEach(models) { model in
+                    ModelRow(
+                        model: model,
+                        isLoaded: inferenceService.loadedModelId == model.id
+                    )
+                }
+                .onDelete { indexSet in
+                    if let index = indexSet.first {
+                        modelToDelete = models[index]
+                    }
+                }
+            } footer: {
+                Text("\(models.count) model\(models.count == 1 ? "" : "s"), \(totalSizeFormatted)")
+            }
+
+            Section("Storage") {
+                storageDashboard
+            }
+        }
+    }
+
+    // MARK: - Storage
+
+    private var storageInfo: some View {
+        let available = FileManager.availableDiskSpace
+        return Text(ByteCountFormatter.string(fromByteCount: available, countStyle: .file) + " free")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    private var storageDashboard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            let totalUsed = models.reduce(Int64(0)) { $0 + $1.fileSizeBytes }
+            let available = FileManager.availableDiskSpace
+
+            LabeledContent("Models Storage") {
+                Text(ByteCountFormatter.string(fromByteCount: totalUsed, countStyle: .file))
+            }
+            LabeledContent("Available Space") {
+                Text(ByteCountFormatter.string(fromByteCount: available, countStyle: .file))
+            }
+
+            if available < 1_000_000_000 {
+                Label(
+                    "Low storage. Consider removing unused models.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var totalSizeFormatted: String {
+        let total = models.reduce(Int64(0)) { $0 + $1.fileSizeBytes }
+        return ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
+    }
+
+    // MARK: - Actions
+
+    private func deleteModel(_ model: LocalModel) {
+        Task {
+            if inferenceService.loadedModelId == model.id {
+                await inferenceService.unloadModel()
+            }
+        }
+
+        let fileURL = model.absolutePath
+        try? FileManager.default.removeItem(at: fileURL)
+        modelContext.delete(model)
+        modelToDelete = nil
+    }
+}
+
+struct ModelRow: View {
+    let model: LocalModel
+    let isLoaded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(model.displayName)
+                    .font(.headline)
+                if isLoaded {
+                    Text("Active")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.green.opacity(0.2))
+                        .foregroundStyle(.green)
+                        .clipShape(Capsule())
+                }
+            }
+            HStack(spacing: 12) {
+                Label(
+                    ByteCountFormatter.string(
+                        fromByteCount: model.fileSizeBytes, countStyle: .file
+                    ),
+                    systemImage: "doc"
+                )
+                Label(model.quantization, systemImage: "cpu")
+                Label(model.modelFamily, systemImage: "brain")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+
+            if let lastUsed = model.lastUsedAt {
+                Text("Last used \(lastUsed.formatted(.relative(presentation: .named)))")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    LibraryView()
+        .environment(InferenceService())
+        .modelContainer(for: LocalModel.self, inMemory: true)
+}

--- a/HearthAI/Features/ModelStore/FeaturedModelDetailView.swift
+++ b/HearthAI/Features/ModelStore/FeaturedModelDetailView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import SwiftData
+
+struct FeaturedModelDetailView: View {
+    let model: FeaturedModel
+    @Environment(DownloadService.self) private var downloadService
+    @Query private var localModels: [LocalModel]
+
+    private var isDownloaded: Bool {
+        localModels.contains { $0.id == model.id }
+    }
+
+    private var activeDownload: DownloadInfo? {
+        downloadService.downloads[model.id]
+    }
+
+    var body: some View {
+        List {
+            Section("Model Info") {
+                LabeledContent("Name", value: model.displayName)
+                LabeledContent("Family", value: model.modelFamily)
+                LabeledContent("Repository", value: model.repoId)
+                LabeledContent("Quantization", value: model.quantization)
+                LabeledContent("Size", value: model.formattedSize)
+            }
+
+            Section("Description") {
+                Text(model.description)
+                    .font(.body)
+            }
+
+            Section {
+                if isDownloaded {
+                    Label("Downloaded", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                } else if let download = activeDownload {
+                    DownloadProgressRow(download: download)
+                } else {
+                    Button {
+                        downloadService.startDownload(
+                            repoId: model.repoId,
+                            fileName: model.fileName,
+                            fileSize: model.sizeBytes
+                        )
+                    } label: {
+                        Label(
+                            "Download (\(model.formattedSize))",
+                            systemImage: "arrow.down.circle"
+                        )
+                    }
+                }
+            }
+        }
+        .navigationTitle(model.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/HearthAI/Features/ModelStore/ModelDetailView.swift
+++ b/HearthAI/Features/ModelStore/ModelDetailView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import SwiftData
+
+struct ModelDetailView: View {
+    let model: HFModelInfo
+    @Environment(DownloadService.self) private var downloadService
+    @Query private var localModels: [LocalModel]
+    @State private var files: [HFFileInfo] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let api = HuggingFaceAPI()
+
+    var body: some View {
+        List {
+            Section("Model Info") {
+                LabeledContent("Repository", value: model.id)
+                LabeledContent("Family", value: model.modelFamily)
+                LabeledContent("Downloads", value: "\(model.downloads)")
+                LabeledContent("Likes", value: "\(model.likes)")
+            }
+
+            Section("Available Files") {
+                if isLoading {
+                    ProgressView("Loading files...")
+                } else if let error = errorMessage {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                } else if files.isEmpty {
+                    Text("No GGUF files found")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(files) { file in
+                        FileRow(
+                            file: file,
+                            repoId: model.id,
+                            isDownloaded: isFileDownloaded(file),
+                            activeDownload: downloadService.downloads[
+                                "\(model.id)/\(file.fileName)"
+                            ]
+                        )
+                    }
+                }
+            }
+        }
+        .navigationTitle(model.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await loadFiles()
+        }
+    }
+
+    private func loadFiles() async {
+        do {
+            files = try await api.listFiles(repoId: model.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func isFileDownloaded(_ file: HFFileInfo) -> Bool {
+        localModels.contains { $0.id == "\(model.id)/\(file.fileName)" }
+    }
+}
+
+struct FileRow: View {
+    let file: HFFileInfo
+    let repoId: String
+    let isDownloaded: Bool
+    let activeDownload: DownloadInfo?
+    @Environment(DownloadService.self) private var downloadService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(file.fileName)
+                .font(.subheadline.bold())
+                .lineLimit(1)
+            HStack(spacing: 12) {
+                Label(file.formattedSize, systemImage: "doc")
+                Label(file.quantization, systemImage: "cpu")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+
+            if isDownloaded {
+                Label("Downloaded", systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            } else if let download = activeDownload {
+                DownloadProgressRow(download: download)
+            } else {
+                Button {
+                    downloadService.startDownload(
+                        repoId: repoId,
+                        fileName: file.fileName,
+                        fileSize: file.size ?? 0
+                    )
+                } label: {
+                    Label("Download", systemImage: "arrow.down.circle")
+                        .font(.caption)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/HearthAI/Features/ModelStore/ModelStoreView.swift
+++ b/HearthAI/Features/ModelStore/ModelStoreView.swift
@@ -1,24 +1,220 @@
 import SwiftUI
+import SwiftData
 
 struct ModelStoreView: View {
+    @Environment(DownloadService.self) private var downloadService
+    @Query private var localModels: [LocalModel]
+    @State private var viewModel = ModelStoreViewModel()
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 16) {
-                Image(systemName: "square.grid.2x2")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.secondary)
-                Text("Model Store")
-                    .font(.title2.bold())
-                Text("Browse and download AI models.\nComing in Phase 2.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
+            List {
+                if !downloadService.activeDownloads.isEmpty {
+                    activeDownloadsSection
+                }
+
+                if viewModel.searchText.isEmpty {
+                    featuredSection
+                } else if viewModel.isSearching {
+                    Section {
+                        ProgressView("Searching...")
+                            .frame(maxWidth: .infinity)
+                    }
+                } else if let error = viewModel.errorMessage {
+                    Section {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                } else {
+                    searchResultsSection
+                }
             }
             .navigationTitle("Models")
+            .searchable(text: $viewModel.searchText, prompt: "Search GGUF models...")
+            .onSubmit(of: .search) {
+                viewModel.search()
+            }
+            .onChange(of: viewModel.searchText) {
+                if viewModel.searchText.isEmpty {
+                    viewModel.clearSearch()
+                }
+            }
         }
+    }
+
+    // MARK: - Active Downloads
+
+    private var activeDownloadsSection: some View {
+        Section("Downloads") {
+            ForEach(downloadService.activeDownloads) { download in
+                DownloadProgressRow(download: download)
+            }
+        }
+    }
+
+    // MARK: - Featured Models
+
+    private var featuredSection: some View {
+        Section("Recommended Models") {
+            ForEach(viewModel.featuredModels) { model in
+                NavigationLink {
+                    FeaturedModelDetailView(model: model)
+                } label: {
+                    FeaturedModelRow(
+                        model: model,
+                        isDownloaded: isModelDownloaded(model.id)
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Search Results
+
+    private var searchResultsSection: some View {
+        Section("Results (\(viewModel.searchResults.count))") {
+            ForEach(viewModel.searchResults) { model in
+                NavigationLink {
+                    ModelDetailView(model: model)
+                } label: {
+                    SearchResultRow(model: model)
+                }
+            }
+
+            if viewModel.searchResults.isEmpty {
+                ContentUnavailableView(
+                    "No Results",
+                    systemImage: "magnifyingglass",
+                    description: Text("Try a different search term.")
+                )
+            }
+        }
+    }
+
+    private func isModelDownloaded(_ modelId: String) -> Bool {
+        localModels.contains { $0.id == modelId }
+    }
+}
+
+// MARK: - Row Views
+
+struct FeaturedModelRow: View {
+    let model: FeaturedModel
+    let isDownloaded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(model.displayName)
+                    .font(.headline)
+                if isDownloaded {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+            }
+            Text(model.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            HStack(spacing: 12) {
+                Label(model.formattedSize, systemImage: "doc")
+                Label(model.quantization, systemImage: "cpu")
+                Label(model.modelFamily, systemImage: "brain")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct SearchResultRow: View {
+    let model: HFModelInfo
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(model.displayName)
+                .font(.headline)
+            Text(model.id)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                Label("\(model.downloads)", systemImage: "arrow.down.circle")
+                Label("\(model.likes)", systemImage: "heart")
+                Label(model.modelFamily, systemImage: "brain")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct DownloadProgressRow: View {
+    @Bindable var download: DownloadInfo
+    @Environment(DownloadService.self) private var downloadService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(download.fileName)
+                .font(.subheadline.bold())
+                .lineLimit(1)
+
+            switch download.status {
+            case .queued:
+                Text("Queued...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .downloading:
+                ProgressView(value: download.progress)
+                HStack {
+                    Text(download.formattedProgress)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Pause") {
+                        downloadService.pauseDownload(id: download.id)
+                    }
+                    .font(.caption)
+                    Button("Cancel", role: .destructive) {
+                        downloadService.cancelDownload(id: download.id)
+                    }
+                    .font(.caption)
+                }
+            case .paused:
+                ProgressView(value: download.progress)
+                    .tint(.orange)
+                HStack {
+                    Text("Paused")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    Spacer()
+                    Button("Resume") {
+                        downloadService.resumeDownload(id: download.id)
+                    }
+                    .font(.caption)
+                    Button("Cancel", role: .destructive) {
+                        downloadService.cancelDownload(id: download.id)
+                    }
+                    .font(.caption)
+                }
+            case .completed:
+                Label("Download complete", systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            case .failed(let error):
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(.vertical, 4)
     }
 }
 
 #Preview {
     ModelStoreView()
+        .environment(DownloadService())
+        .modelContainer(for: LocalModel.self, inMemory: true)
 }

--- a/HearthAI/Features/ModelStore/ModelStoreViewModel.swift
+++ b/HearthAI/Features/ModelStore/ModelStoreViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+@Observable
+final class ModelStoreViewModel {
+    var searchText = ""
+    var searchResults: [HFModelInfo] = []
+    var isSearching = false
+    var errorMessage: String?
+    var featuredModels: [FeaturedModel] = []
+
+    // Tracks file listings per repo
+    var repoFiles: [String: [HFFileInfo]] = [:]
+    var isLoadingFiles: [String: Bool] = [:]
+
+    private let api = HuggingFaceAPI()
+    private var searchTask: Task<Void, Never>?
+
+    init() {
+        featuredModels = FeaturedModel.loadFeatured()
+    }
+
+    func search() {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            searchResults = []
+            return
+        }
+
+        searchTask?.cancel()
+        searchTask = Task {
+            isSearching = true
+            errorMessage = nil
+
+            do {
+                let results = try await api.searchModels(query: query)
+                if !Task.isCancelled {
+                    searchResults = results
+                }
+            } catch {
+                if !Task.isCancelled {
+                    errorMessage = error.localizedDescription
+                }
+            }
+
+            if !Task.isCancelled {
+                isSearching = false
+            }
+        }
+    }
+
+    func loadFiles(for repoId: String) async {
+        guard repoFiles[repoId] == nil else { return }
+        isLoadingFiles[repoId] = true
+
+        do {
+            let files = try await api.listFiles(repoId: repoId)
+            repoFiles[repoId] = files
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoadingFiles[repoId] = false
+    }
+
+    func clearSearch() {
+        searchText = ""
+        searchResults = []
+        errorMessage = nil
+    }
+}

--- a/HearthAI/Resources/FeaturedModels.json
+++ b/HearthAI/Resources/FeaturedModels.json
@@ -1,0 +1,47 @@
+[
+    {
+        "repoId": "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+        "fileName": "qwen2.5-0.5b-instruct-q4_k_m.gguf",
+        "displayName": "Qwen 2.5 0.5B",
+        "modelFamily": "Qwen",
+        "quantization": "Q4_K_M",
+        "sizeBytes": 469000000,
+        "description": "Ultra-compact model. Great for testing and low-memory devices."
+    },
+    {
+        "repoId": "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
+        "fileName": "qwen2.5-1.5b-instruct-q4_k_m.gguf",
+        "displayName": "Qwen 2.5 1.5B",
+        "modelFamily": "Qwen",
+        "quantization": "Q4_K_M",
+        "sizeBytes": 1100000000,
+        "description": "Small but capable. Good balance of speed and quality."
+    },
+    {
+        "repoId": "bartowski/Llama-3.2-1B-Instruct-GGUF",
+        "fileName": "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "displayName": "Llama 3.2 1B",
+        "modelFamily": "Llama",
+        "quantization": "Q4_K_M",
+        "sizeBytes": 776000000,
+        "description": "Meta's compact Llama model. Fast inference on mobile."
+    },
+    {
+        "repoId": "bartowski/Llama-3.2-3B-Instruct-GGUF",
+        "fileName": "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+        "displayName": "Llama 3.2 3B",
+        "modelFamily": "Llama",
+        "quantization": "Q4_K_M",
+        "sizeBytes": 2020000000,
+        "description": "Strong reasoning. Recommended for devices with 6GB+ RAM."
+    },
+    {
+        "repoId": "bartowski/Phi-3.5-mini-instruct-GGUF",
+        "fileName": "Phi-3.5-mini-instruct-Q4_K_M.gguf",
+        "displayName": "Phi 3.5 Mini",
+        "modelFamily": "Phi",
+        "quantization": "Q4_K_M",
+        "sizeBytes": 2180000000,
+        "description": "Microsoft's efficient model. Excellent for its size."
+    }
+]

--- a/HearthAI/Services/Download/DownloadService.swift
+++ b/HearthAI/Services/Download/DownloadService.swift
@@ -1,0 +1,196 @@
+import Foundation
+import SwiftData
+
+@Observable
+final class DownloadService: NSObject {
+    private(set) var downloads: [String: DownloadInfo] = [:]
+    var onDownloadComplete: ((DownloadInfo) -> Void)?
+
+    private let api = HuggingFaceAPI()
+    private var backgroundSession: URLSession!
+    private var taskToDownloadId: [Int: String] = [:]
+
+    override init() {
+        super.init()
+        let config = URLSessionConfiguration.background(
+            withIdentifier: "ai.hearth.download"
+        )
+        config.isDiscretionary = false
+        config.sessionSendsLaunchEvents = true
+        backgroundSession = URLSession(
+            configuration: config,
+            delegate: self,
+            delegateQueue: nil
+        )
+    }
+
+    var activeDownloads: [DownloadInfo] {
+        Array(downloads.values).sorted { $0.id < $1.id }
+    }
+
+    var hasActiveDownloads: Bool {
+        downloads.values.contains {
+            if case .downloading = $0.status { return true }
+            if case .queued = $0.status { return true }
+            return false
+        }
+    }
+
+    // MARK: - Download Control
+
+    func startDownload(repoId: String, fileName: String, fileSize: Int64) {
+        let downloadId = "\(repoId)/\(fileName)"
+        guard downloads[downloadId] == nil else { return }
+
+        let info = DownloadInfo(
+            id: downloadId,
+            repoId: repoId,
+            fileName: fileName,
+            fileSize: fileSize
+        )
+
+        let url = api.downloadURL(repoId: repoId, fileName: fileName)
+        let task = backgroundSession.downloadTask(with: url)
+
+        info.task = task
+        info.status = .downloading
+        downloads[downloadId] = info
+        taskToDownloadId[task.taskIdentifier] = downloadId
+
+        task.resume()
+    }
+
+    func pauseDownload(id: String) {
+        guard let info = downloads[id], let task = info.task else { return }
+        task.cancel { [weak self] data in
+            DispatchQueue.main.async {
+                self?.downloads[id]?.resumeData = data
+                self?.downloads[id]?.status = .paused
+            }
+        }
+    }
+
+    func resumeDownload(id: String) {
+        guard let info = downloads[id] else { return }
+
+        let task: URLSessionDownloadTask
+        if let resumeData = info.resumeData {
+            task = backgroundSession.downloadTask(withResumeData: resumeData)
+        } else {
+            let url = api.downloadURL(repoId: info.repoId, fileName: info.fileName)
+            task = backgroundSession.downloadTask(with: url)
+        }
+
+        info.task = task
+        info.status = .downloading
+        info.resumeData = nil
+        taskToDownloadId[task.taskIdentifier] = id
+
+        task.resume()
+    }
+
+    func cancelDownload(id: String) {
+        guard let info = downloads[id] else { return }
+        info.task?.cancel()
+        downloads.removeValue(forKey: id)
+    }
+
+    func removeDownload(id: String) {
+        downloads.removeValue(forKey: id)
+    }
+
+    // MARK: - File Management
+
+    private func moveDownloadedFile(from tempURL: URL, downloadInfo: DownloadInfo) throws -> String {
+        let modelsDir = FileManager.modelsDirectory
+        let repoDir = modelsDir.appendingPathComponent(
+            downloadInfo.repoId.replacingOccurrences(of: "/", with: "_"),
+            isDirectory: true
+        )
+
+        try FileManager.default.createDirectory(
+            at: repoDir,
+            withIntermediateDirectories: true
+        )
+
+        let destURL = repoDir.appendingPathComponent(downloadInfo.fileName)
+
+        if FileManager.default.fileExists(atPath: destURL.path) {
+            try FileManager.default.removeItem(at: destURL)
+        }
+
+        try FileManager.default.moveItem(at: tempURL, to: destURL)
+
+        let repoComponent = downloadInfo.repoId.replacingOccurrences(of: "/", with: "_")
+        return "\(repoComponent)/\(downloadInfo.fileName)"
+    }
+}
+
+// MARK: - URLSessionDownloadDelegate
+
+extension DownloadService: URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let downloadId = taskToDownloadId[downloadTask.taskIdentifier],
+              let info = downloads[downloadId] else { return }
+
+        do {
+            let localPath = try moveDownloadedFile(from: location, downloadInfo: info)
+            DispatchQueue.main.async {
+                info.status = .completed
+                info.progress = 1.0
+                self.onDownloadComplete?(info)
+            }
+            _ = localPath
+        } catch {
+            DispatchQueue.main.async {
+                info.status = .failed(error.localizedDescription)
+            }
+        }
+
+        taskToDownloadId.removeValue(forKey: downloadTask.taskIdentifier)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard let downloadId = taskToDownloadId[downloadTask.taskIdentifier],
+              let info = downloads[downloadId] else { return }
+
+        let total = totalBytesExpectedToWrite > 0
+            ? totalBytesExpectedToWrite
+            : info.fileSize
+        let progress = total > 0 ? Double(totalBytesWritten) / Double(total) : 0
+
+        DispatchQueue.main.async {
+            info.progress = progress
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        guard let error,
+              let downloadId = taskToDownloadId[task.taskIdentifier],
+              let info = downloads[downloadId] else { return }
+
+        let nsError = error as NSError
+        if nsError.code == NSURLErrorCancelled {
+            return
+        }
+
+        DispatchQueue.main.async {
+            info.status = .failed(error.localizedDescription)
+        }
+        taskToDownloadId.removeValue(forKey: task.taskIdentifier)
+    }
+}

--- a/HearthAI/Services/Download/DownloadState.swift
+++ b/HearthAI/Services/Download/DownloadState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum DownloadStatus: Sendable {
+    case queued
+    case downloading
+    case paused
+    case completed
+    case failed(String)
+}
+
+@Observable
+final class DownloadInfo: Identifiable {
+    let id: String
+    let repoId: String
+    let fileName: String
+    let fileSize: Int64
+    var progress: Double = 0
+    var status: DownloadStatus = .queued
+    var resumeData: Data?
+    var task: URLSessionDownloadTask?
+
+    init(id: String, repoId: String, fileName: String, fileSize: Int64) {
+        self.id = id
+        self.repoId = repoId
+        self.fileName = fileName
+        self.fileSize = fileSize
+    }
+
+    var formattedProgress: String {
+        let downloaded = Int64(Double(fileSize) * progress)
+        let total = ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+        let done = ByteCountFormatter.string(fromByteCount: downloaded, countStyle: .file)
+        return "\(done) / \(total)"
+    }
+}

--- a/HearthAI/Services/HuggingFace/FeaturedModel.swift
+++ b/HearthAI/Services/HuggingFace/FeaturedModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct FeaturedModel: Codable, Identifiable {
+    let repoId: String
+    let fileName: String
+    let displayName: String
+    let modelFamily: String
+    let quantization: String
+    let sizeBytes: Int64
+    let description: String
+
+    var id: String { "\(repoId)/\(fileName)" }
+
+    var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+    }
+
+    static func loadFeatured() -> [FeaturedModel] {
+        guard let url = Bundle.main.url(forResource: "FeaturedModels", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let models = try? JSONDecoder().decode([FeaturedModel].self, from: data) else {
+            return []
+        }
+        return models
+    }
+}

--- a/HearthAI/Services/HuggingFace/HFModelInfo.swift
+++ b/HearthAI/Services/HuggingFace/HFModelInfo.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct HFModelInfo: Codable, Identifiable, Sendable {
+    let id: String
+    let author: String?
+    let downloads: Int
+    let likes: Int
+    let tags: [String]
+    let isPrivate: Bool
+    let isGated: Bool?
+    let lastModified: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case author
+        case downloads
+        case likes
+        case tags
+        case isPrivate = "private"
+        case isGated = "gated"
+        case lastModified
+    }
+
+    var displayName: String {
+        id.components(separatedBy: "/").last ?? id
+    }
+
+    var modelFamily: String {
+        let name = displayName.lowercased()
+        let families = ["llama", "mistral", "phi", "qwen", "gemma", "smollm", "tinyllama"]
+        return families.first { name.contains($0) }?.capitalized ?? "Unknown"
+    }
+}
+
+struct HFFileInfo: Codable, Identifiable, Sendable {
+    let type: String
+    let path: String
+    let size: Int64?
+
+    var id: String { path }
+
+    var fileName: String {
+        path.components(separatedBy: "/").last ?? path
+    }
+
+    var isGGUF: Bool {
+        fileName.hasSuffix(".gguf")
+    }
+
+    var quantization: String {
+        let name = fileName.lowercased()
+        let quants = [
+            "q2_k", "q3_k_s", "q3_k_m", "q3_k_l",
+            "q4_0", "q4_1", "q4_k_s", "q4_k_m",
+            "q5_0", "q5_1", "q5_k_s", "q5_k_m",
+            "q6_k", "q8_0", "f16", "f32",
+            "iq2_xxs", "iq2_xs", "iq3_xxs", "iq3_xs",
+        ]
+        return quants.first { name.contains($0) }?.uppercased() ?? "Unknown"
+    }
+
+    var formattedSize: String {
+        guard let size else { return "Unknown" }
+        return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+    }
+}

--- a/HearthAI/Services/HuggingFace/HuggingFaceAPI.swift
+++ b/HearthAI/Services/HuggingFace/HuggingFaceAPI.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+final class HuggingFaceAPI: Sendable {
+    // swiftlint:disable:next force_unwrapping
+    private let baseURL = URL(string: "https://huggingface.co/api")!
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func searchModels(query: String, limit: Int = 20) async throws -> [HFModelInfo] {
+        var components = URLComponents(url: baseURL.appendingPathComponent("models"), resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "search", value: query),
+            URLQueryItem(name: "filter", value: "gguf"),
+            URLQueryItem(name: "sort", value: "downloads"),
+            URLQueryItem(name: "direction", value: "-1"),
+            URLQueryItem(name: "limit", value: String(limit)),
+        ]
+
+        guard let url = components?.url else {
+            throw HFAPIError.invalidURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+        try validateResponse(response)
+
+        let models = try JSONDecoder().decode([HFModelInfo].self, from: data)
+        return models.filter { !$0.isPrivate && $0.isGated != true }
+    }
+
+    func getModelInfo(repoId: String) async throws -> HFModelInfo {
+        let url = baseURL
+            .appendingPathComponent("models")
+            .appendingPathComponent(repoId)
+
+        let (data, response) = try await session.data(from: url)
+        try validateResponse(response)
+
+        return try JSONDecoder().decode(HFModelInfo.self, from: data)
+    }
+
+    func listFiles(repoId: String) async throws -> [HFFileInfo] {
+        let url = baseURL
+            .appendingPathComponent("models")
+            .appendingPathComponent(repoId)
+            .appendingPathComponent("tree")
+            .appendingPathComponent("main")
+
+        let (data, response) = try await session.data(from: url)
+        try validateResponse(response)
+
+        let files = try JSONDecoder().decode([HFFileInfo].self, from: data)
+        return files.filter { $0.isGGUF }
+    }
+
+    func downloadURL(repoId: String, fileName: String) -> URL {
+        let encoded = fileName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? fileName
+        // swiftlint:disable:next force_unwrapping
+        return URL(string: "https://huggingface.co/\(repoId)/resolve/main/\(encoded)")!
+    }
+
+    private func validateResponse(_ response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HFAPIError.invalidResponse
+        }
+        switch httpResponse.statusCode {
+        case 200...299:
+            return
+        case 404:
+            throw HFAPIError.notFound
+        case 429:
+            throw HFAPIError.rateLimited
+        default:
+            throw HFAPIError.httpError(statusCode: httpResponse.statusCode)
+        }
+    }
+}
+
+enum HFAPIError: Error, LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case notFound
+    case rateLimited
+    case httpError(statusCode: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "Invalid URL"
+        case .invalidResponse:
+            "Invalid response from server"
+        case .notFound:
+            "Model not found"
+        case .rateLimited:
+            "Rate limited. Please try again later."
+        case .httpError(let code):
+            "Server error (HTTP \(code))"
+        }
+    }
+}

--- a/HearthAITests/HearthAITests.swift
+++ b/HearthAITests/HearthAITests.swift
@@ -22,3 +22,45 @@ import Testing
     #expect(viewModel.messages.isEmpty)
     #expect(viewModel.streamingText.isEmpty)
 }
+
+// MARK: - Phase 2 Tests
+
+@Test func hfFileInfoGGUFDetection() {
+    let ggufFile = HFFileInfo(type: "file", path: "model-q4_k_m.gguf", size: 1000)
+    let otherFile = HFFileInfo(type: "file", path: "README.md", size: 500)
+
+    #expect(ggufFile.isGGUF == true)
+    #expect(otherFile.isGGUF == false)
+}
+
+@Test func hfFileInfoQuantizationParsing() {
+    let file = HFFileInfo(type: "file", path: "llama-3.2-1b-q4_k_m.gguf", size: 1000)
+    #expect(file.quantization == "Q4_K_M")
+
+    let file2 = HFFileInfo(type: "file", path: "model-q8_0.gguf", size: 2000)
+    #expect(file2.quantization == "Q8_0")
+}
+
+@Test func featuredModelsLoad() {
+    let models = FeaturedModel.loadFeatured()
+    #expect(!models.isEmpty)
+    #expect(models.first?.repoId.contains("/") == true)
+}
+
+@Test func downloadInfoProgressFormat() {
+    let info = DownloadInfo(
+        id: "test/model.gguf",
+        repoId: "test",
+        fileName: "model.gguf",
+        fileSize: 1_000_000_000
+    )
+    info.progress = 0.5
+    #expect(info.formattedProgress.contains("/"))
+}
+
+@Test func modelStoreViewModelInit() {
+    let viewModel = ModelStoreViewModel()
+    #expect(!viewModel.featuredModels.isEmpty)
+    #expect(viewModel.searchResults.isEmpty)
+    #expect(viewModel.isSearching == false)
+}


### PR DESCRIPTION
## Summary
- **HuggingFace API client** (#8) — search GGUF models, list repo files, generate download URLs
- **Background download service** (#9) — `URLSessionDownloadDelegate` with pause/resume/cancel, progress tracking
- **SwiftData persistence** (#10) — download completion saves `LocalModel` records automatically
- **Model Store UI** (#11) — featured models section, search with results, model detail views with file picker
- **Library view** (#12) — downloaded models list, storage dashboard, swipe-to-delete with file cleanup
- **Navigation & model picker** (#13) — 4-tab layout (Chat, Models, Library, Settings), model picker sheet in Chat toolbar

Closes #8, closes #9, closes #10, closes #11, closes #12, closes #13

## New Files
- `Services/HuggingFace/` — `HuggingFaceAPI`, `HFModelInfo`, `HFFileInfo`, `FeaturedModel`
- `Services/Download/` — `DownloadService`, `DownloadState`
- `Features/ModelStore/` — `ModelStoreViewModel`, `ModelDetailView`, `FeaturedModelDetailView`
- `Features/Library/` — `LibraryView` with storage dashboard
- `Features/Chat/ModelPickerSheet.swift` — model selector sheet
- `Resources/FeaturedModels.json` — 5 curated models (Qwen 0.5B/1.5B, Llama 1B/3B, Phi 3.5 Mini)

## Test plan
- [x] Project builds for iOS Simulator
- [x] SwiftLint passes with no violations
- [x] All 8 unit tests pass (3 existing + 5 new)
- [ ] CI pipeline passes
- [ ] Manual: search models, view details, start/pause/resume downloads
- [ ] Manual: library shows downloaded models, delete works
- [ ] Manual: model picker loads model for chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)