### PR TITLE
Add multi-platform support for iPad, macOS, and visionOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Lint
         run: swiftlint lint --strict --reporter github-actions-logging
 
-  build-and-test:
-    name: Build & Test
+  build-and-test-ios:
+    name: Build & Test (iOS)
     runs-on: macos-15
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
         run: xcodebuild -version
 
       - name: Build llama.cpp XCFramework
-        run: bash scripts/build-xcframework.sh
+        run: bash scripts/build-xcframework.sh --platforms ios
 
       - name: Generate Xcode Project
         run: xcodegen generate
@@ -99,4 +99,50 @@ jobs:
             -destination '${{ steps.simulator.outputs.destination }}' \
             CODE_SIGNING_ALLOWED=NO \
             EXCLUDED_ARCHS='x86_64' \
+            2>&1 | tail -100
+
+  build-and-test-macos:
+    name: Build & Test (macOS)
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Select Xcode
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using Xcode at: $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+
+      - name: Show Xcode Version
+        run: xcodebuild -version
+
+      - name: Build llama.cpp XCFramework
+        run: bash scripts/build-xcframework.sh --platforms ios,macos
+
+      - name: Generate Xcode Project
+        run: xcodegen generate
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project HearthAI.xcodeproj \
+            -scheme HearthAI \
+            -destination 'platform=macOS' \
+            -quiet \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Test
+        timeout-minutes: 10
+        run: |
+          xcodebuild test \
+            -project HearthAI.xcodeproj \
+            -scheme HearthAI \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
             2>&1 | tail -100

--- a/HearthAI.xcodeproj/project.pbxproj
+++ b/HearthAI.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		C7F2A3D0417981686B4E3052 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397BD3F6A93E6069059BBBBF /* AppState.swift */; };
 		CBB8F9486DF5B9A8F6F350A7 /* DeviceCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79297A2500C2BFE5F893531F /* DeviceCapability.swift */; };
 		CDB4579A512B12F942C6E768 /* ModelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */; };
+		CE92A1FB39AD10CF859706C5 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80C3E2B605DDA7CD3DF5A1E /* TestModelContainer.swift */; };
 		DFE0909D9533627F1E418FED /* DownloadServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B7417DFD3FFE4FD4E79869 /* DownloadServiceTests.swift */; };
 		F09B9F855596430552F5A8FE /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890BDB102F2FE40261F5A508 /* ChatViewModel.swift */; };
 		F1AD3F2C8048B14FC787BF4D /* FileManager+AppSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7FB411EA3CC770171848E7 /* FileManager+AppSupport.swift */; };
@@ -98,6 +99,7 @@
 		CE68C23BD50C2CE6816C8530 /* LocalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModel.swift; sourceTree = "<group>"; };
 		E0E39895107391568ACB967A /* DeviceCapabilityEdgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCapabilityEdgeTests.swift; sourceTree = "<group>"; };
 		E1307661B3414B71F26366B8 /* InferenceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceConfiguration.swift; sourceTree = "<group>"; };
+		E80C3E2B605DDA7CD3DF5A1E /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
 		E903921FAA09285C7EC06626 /* HearthAIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HearthAIApp.swift; sourceTree = "<group>"; };
 		EA5163E146981BFA10057E46 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -141,6 +143,7 @@
 				29482A421FB1811401D6034E /* HearthAITests.swift */,
 				C31143EB8502183C8C805EDD /* HuggingFaceTests.swift */,
 				8DD6808C0B4D60CE08267A51 /* SwiftDataCascadeTests.swift */,
+				E80C3E2B605DDA7CD3DF5A1E /* TestModelContainer.swift */,
 			);
 			path = HearthAITests;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 				FDF5740963252281A3030A24 /* HearthAITests.swift in Sources */,
 				8A5B36588755EFFB4BEA89EF /* HuggingFaceTests.swift in Sources */,
 				910A8C1FFD6C00FCB79D6E0D /* SwiftDataCascadeTests.swift in Sources */,
+				CE92A1FB39AD10CF859706C5 /* TestModelContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -538,14 +542,17 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.9;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -553,6 +560,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"BUNDLE_LOADER[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -560,9 +568,14 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAITests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/HearthAI";
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI";
 			};
 			name = Debug;
 		};
@@ -614,13 +627,16 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.9;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
@@ -642,9 +658,13 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI;
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};
@@ -666,9 +686,13 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI;
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -676,6 +700,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"BUNDLE_LOADER[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -683,9 +708,14 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAITests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/HearthAI";
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI";
 			};
 			name = Release;
 		};

--- a/HearthAI.xcodeproj/xcshareddata/xcschemes/HearthAI.xcscheme
+++ b/HearthAI.xcodeproj/xcshareddata/xcschemes/HearthAI.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "45992FD008C054DABF552FDB"
+               BuildableName = "HearthAI.app"
+               BlueprintName = "HearthAI"
+               ReferencedContainer = "container:HearthAI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA86BD510EA5C3E0E637CA79"
+               BuildableName = "HearthAITests.xctest"
+               BlueprintName = "HearthAITests"
+               ReferencedContainer = "container:HearthAI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "45992FD008C054DABF552FDB"
+            BuildableName = "HearthAI.app"
+            BlueprintName = "HearthAI"
+            ReferencedContainer = "container:HearthAI.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA86BD510EA5C3E0E637CA79"
+               BuildableName = "HearthAITests.xctest"
+               BlueprintName = "HearthAITests"
+               ReferencedContainer = "container:HearthAI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "45992FD008C054DABF552FDB"
+            BuildableName = "HearthAI.app"
+            BlueprintName = "HearthAI"
+            ReferencedContainer = "container:HearthAI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "45992FD008C054DABF552FDB"
+            BuildableName = "HearthAI.app"
+            BlueprintName = "HearthAI"
+            ReferencedContainer = "container:HearthAI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HearthAI/App/ContentView.swift
+++ b/HearthAI/App/ContentView.swift
@@ -1,6 +1,28 @@
 import SwiftUI
 
+enum NavigationItem: Hashable {
+    case chat, models, library, settings
+}
+
 struct ContentView: View {
+    #if os(macOS)
+    var body: some View {
+        SidebarContentView()
+    }
+    #else
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        if sizeClass == .regular {
+            SidebarContentView()
+        } else {
+            TabContentView()
+        }
+    }
+    #endif
+}
+
+struct TabContentView: View {
     var body: some View {
         TabView {
             ChatView()
@@ -14,6 +36,43 @@ struct ContentView: View {
 
             SettingsView()
                 .tabItem { Label("Settings", systemImage: "gear") }
+        }
+    }
+}
+
+struct SidebarContentView: View {
+    @State private var selection: NavigationItem? = .chat
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                Label("Chat", systemImage: "bubble.left.and.bubble.right")
+                    .tag(NavigationItem.chat)
+                Label("Models", systemImage: "square.grid.2x2")
+                    .tag(NavigationItem.models)
+                Label("Library", systemImage: "internaldrive")
+                    .tag(NavigationItem.library)
+                Label("Settings", systemImage: "gear")
+                    .tag(NavigationItem.settings)
+            }
+            .navigationTitle("Hearth AI")
+        } detail: {
+            switch selection {
+            case .chat:
+                ChatView()
+            case .models:
+                ModelStoreView()
+            case .library:
+                LibraryView()
+            case .settings:
+                SettingsView()
+            case nil:
+                ContentUnavailableView(
+                    "Select an Item",
+                    systemImage: "sidebar.left",
+                    description: Text("Choose a section from the sidebar.")
+                )
+            }
         }
     }
 }

--- a/HearthAI/App/HearthAIApp.swift
+++ b/HearthAI/App/HearthAIApp.swift
@@ -24,7 +24,20 @@ struct HearthAIApp: App {
                     setupDownloadCompletion()
                 }
         }
+        #if os(macOS)
+        .defaultSize(width: 1000, height: 700)
+        #endif
         .modelContainer(modelContainer)
+
+        #if os(macOS)
+        Settings {
+            SettingsView()
+                .environment(appState)
+                .environment(appState.inferenceService)
+                .environment(appState.downloadService)
+                .modelContainer(modelContainer)
+        }
+        #endif
     }
 
     private func setupDownloadCompletion() {

--- a/HearthAI/Features/Chat/ChatSettingsSheet.swift
+++ b/HearthAI/Features/Chat/ChatSettingsSheet.swift
@@ -40,12 +40,14 @@ struct ChatSettingsSheet: View {
                 }
             }
             .navigationTitle("Chat Settings")
+            #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
                         onSave(systemPrompt, temperature, topP)
                         dismiss()

--- a/HearthAI/Features/Chat/ChatView.swift
+++ b/HearthAI/Features/Chat/ChatView.swift
@@ -21,7 +21,9 @@ struct ChatView: View {
                 inputBar
             }
             .navigationTitle("Hearth AI")
+            #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar { chatToolbar }
             .sheet(isPresented: $showModelPicker) {
                 ModelPickerSheet()
@@ -44,7 +46,7 @@ struct ChatView: View {
 
     @ToolbarContentBuilder
     private var chatToolbar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
+        ToolbarItem(placement: .navigation) {
             HStack(spacing: 12) {
                 Button {
                     showConversations = true
@@ -65,7 +67,7 @@ struct ChatView: View {
                 }
             }
         }
-        ToolbarItem(placement: .topBarTrailing) {
+        ToolbarItem(placement: .primaryAction) {
             Menu {
                 Button {
                     viewModel.newConversation()

--- a/HearthAI/Features/Chat/ConversationListView.swift
+++ b/HearthAI/Features/Chat/ConversationListView.swift
@@ -49,12 +49,14 @@ struct ConversationListView: View {
                 }
             }
             .navigationTitle("Conversations")
+            #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
                 }
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         onNew()
                         dismiss()

--- a/HearthAI/Features/Chat/MessageBubble.swift
+++ b/HearthAI/Features/Chat/MessageBubble.swift
@@ -1,4 +1,9 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 struct MessageBubble: View {
     let role: MessageRole
@@ -32,7 +37,7 @@ struct MessageBubble: View {
                     .textSelection(.enabled)
                     .contextMenu {
                         Button {
-                            UIPasteboard.general.string = content
+                            copyToClipboard(content)
                             showCopied = true
                         } label: {
                             Label("Copy", systemImage: "doc.on.doc")
@@ -59,11 +64,24 @@ struct MessageBubble: View {
     }
 
     private var bubbleColor: Color {
+        #if canImport(UIKit)
         role == .user ? .accentColor : Color(.systemGray5)
+        #else
+        role == .user ? .accentColor : Color(nsColor: .controlBackgroundColor)
+        #endif
     }
 
     private var bubbleShape: some Shape {
         RoundedRectangle(cornerRadius: 16, style: .continuous)
+    }
+
+    private func copyToClipboard(_ text: String) {
+        #if canImport(UIKit)
+        UIPasteboard.general.string = text
+        #elseif canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #endif
     }
 }
 

--- a/HearthAI/Features/Chat/ModelPickerSheet.swift
+++ b/HearthAI/Features/Chat/ModelPickerSheet.swift
@@ -49,13 +49,15 @@ struct ModelPickerSheet: View {
                 }
             }
             .navigationTitle("Select Model")
+            #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
                 }
                 if inferenceService.isModelLoaded {
-                    ToolbarItem(placement: .topBarTrailing) {
+                    ToolbarItem(placement: .primaryAction) {
                         Button("Unload") {
                             Task { await inferenceService.unloadModel() }
                         }

--- a/HearthAI/Features/Library/LibraryView.swift
+++ b/HearthAI/Features/Library/LibraryView.swift
@@ -18,7 +18,7 @@ struct LibraryView: View {
             }
             .navigationTitle("Library")
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .primaryAction) {
                     storageInfo
                 }
             }

--- a/HearthAI/Features/ModelStore/FeaturedModelDetailView.swift
+++ b/HearthAI/Features/ModelStore/FeaturedModelDetailView.swift
@@ -56,7 +56,9 @@ struct FeaturedModelDetailView: View {
             }
         }
         .navigationTitle(model.displayName)
+        #if !os(macOS)
         .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 
     @ViewBuilder

--- a/HearthAI/Features/ModelStore/ModelDetailView.swift
+++ b/HearthAI/Features/ModelStore/ModelDetailView.swift
@@ -44,7 +44,9 @@ struct ModelDetailView: View {
             }
         }
         .navigationTitle(model.displayName)
+        #if !os(macOS)
         .navigationBarTitleDisplayMode(.inline)
+        #endif
         .task {
             await loadFiles()
         }

--- a/HearthAI/Features/Settings/SettingsView.swift
+++ b/HearthAI/Features/Settings/SettingsView.swift
@@ -99,7 +99,9 @@ struct LicensesView: View {
             }
         }
         .navigationTitle("Licenses")
+        #if !os(macOS)
         .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 }
 

--- a/HearthAI/Services/Download/DownloadService.swift
+++ b/HearthAI/Services/Download/DownloadService.swift
@@ -20,7 +20,9 @@ final class DownloadService: NSObject {
             withIdentifier: "ai.hearth.download"
         )
         config.isDiscretionary = false
+        #if os(iOS) || os(visionOS)
         config.sessionSendsLaunchEvents = true
+        #endif
         backgroundSession = URLSession(
             configuration: config,
             delegate: self,

--- a/HearthAI/Services/Inference/DeviceCapability.swift
+++ b/HearthAI/Services/Inference/DeviceCapability.swift
@@ -2,19 +2,31 @@ import Foundation
 
 enum DeviceCapability {
     static var availableMemoryBytes: Int64 {
+        #if os(macOS)
+        // macOS doesn't have os_proc_available_memory(); use total physical memory
+        // as a reasonable proxy since macOS has virtual memory and swap
+        return totalMemoryBytes
+        #else
         let available = Int64(os_proc_available_memory())
         // os_proc_available_memory() returns 0 on the simulator
         if available <= 0 {
             return totalMemoryBytes
         }
         return available
+        #endif
     }
 
     static var totalMemoryBytes: Int64 {
         Int64(ProcessInfo.processInfo.physicalMemory)
     }
 
-    static let memoryOverheadBytes: Int64 = 2_000_000_000 // 2 GB
+    static let memoryOverheadBytes: Int64 = {
+        #if os(macOS)
+        return 1_000_000_000 // 1 GB on macOS (has virtual memory and swap)
+        #else
+        return 2_000_000_000 // 2 GB on iOS/visionOS
+        #endif
+    }()
 
     static func canRunModel(fileSizeBytes: Int64) -> ModelFitResult {
         let required = fileSizeBytes + memoryOverheadBytes

--- a/HearthAI/Services/Inference/InferenceService.swift
+++ b/HearthAI/Services/Inference/InferenceService.swift
@@ -1,6 +1,8 @@
 import Foundation
 import LlamaCpp
+#if canImport(UIKit)
 import UIKit
+#endif
 
 @MainActor
 @Observable
@@ -12,6 +14,9 @@ final class InferenceService {
 
     private var context: LlamaContext?
     private nonisolated(unsafe) var notificationObservers: [Any] = []
+    #if os(macOS)
+    private nonisolated(unsafe) var memoryPressureSource: DispatchSourceMemoryPressure?
+    #endif
 
     init() {
         setupMemoryWarningObserver()
@@ -23,6 +28,9 @@ final class InferenceService {
             NotificationCenter.default.removeObserver(observer)
         }
         backgroundTask?.cancel()
+        #if os(macOS)
+        memoryPressureSource?.cancel()
+        #endif
     }
 
     // MARK: - Model Lifecycle
@@ -111,6 +119,7 @@ final class InferenceService {
     // MARK: - Memory Management
 
     private func setupMemoryWarningObserver() {
+        #if canImport(UIKit)
         let observer = NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
@@ -120,9 +129,22 @@ final class InferenceService {
             Task { @MainActor in await self.unloadModel() }
         }
         notificationObservers.append(observer)
+        #elseif os(macOS)
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in await self.unloadModel() }
+        }
+        source.resume()
+        memoryPressureSource = source
+        #endif
     }
 
     private func setupBackgroundObservers() {
+        #if canImport(UIKit)
         let bgObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didEnterBackgroundNotification,
             object: nil,
@@ -140,6 +162,8 @@ final class InferenceService {
             Task { @MainActor in self?.cancelBackgroundUnloadTimer() }
         }
         notificationObservers.append(fgObserver)
+        #endif
+        // macOS: no background unload — apps don't suspend like iOS
     }
 
     private nonisolated(unsafe) var backgroundTask: Task<Void, Never>?

--- a/HearthAITests/ChatViewModelPersistenceTests.swift
+++ b/HearthAITests/ChatViewModelPersistenceTests.swift
@@ -3,173 +3,176 @@ import SwiftData
 import Testing
 @testable import HearthAI
 
-// MARK: - Helpers
-
+@Suite(.serialized)
 @MainActor
-private func makeContext() throws -> ModelContext {
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
-    let container = try ModelContainer(
-        for: Conversation.self, Message.self, LocalModel.self,
-        configurations: config
-    )
-    return container.mainContext
-}
+struct ChatViewModelPersistenceTests {
 
-// MARK: - Stop-Generating Guard
+    // MARK: - Stop-Generating Guard
 
-@Test @MainActor func stopGeneratingWhenNotGeneratingIsNoOp() async {
-    let viewModel = ChatViewModel()
-    viewModel.streamingText = "partial text"
-    viewModel.isGenerating = false
+    @Test func stopGeneratingWhenNotGeneratingIsNoOp() async {
+        let viewModel = ChatViewModel()
+        viewModel.streamingText = "partial text"
+        viewModel.isGenerating = false
 
-    await viewModel.stopGenerating()
+        await viewModel.stopGenerating()
 
-    #expect(viewModel.messages.isEmpty, "No message should be appended when not generating")
-    #expect(viewModel.streamingText == "partial text", "Text should remain unchanged")
-}
+        #expect(viewModel.messages.isEmpty, "No message should be appended when not generating")
+        #expect(viewModel.streamingText == "partial text", "Text should remain unchanged")
+    }
 
-@Test @MainActor func stopGeneratingSavesPartialText() async {
-    let viewModel = ChatViewModel()
-    viewModel.isGenerating = true
-    viewModel.streamingText = "Hello world"
+    @Test func stopGeneratingSavesPartialText() async {
+        let viewModel = ChatViewModel()
+        viewModel.isGenerating = true
+        viewModel.streamingText = "Hello world"
 
-    await viewModel.stopGenerating()
+        await viewModel.stopGenerating()
 
-    #expect(viewModel.messages.count == 1)
-    #expect(viewModel.messages.first?.role == .assistant)
-    #expect(viewModel.messages.first?.content == "Hello world")
-    #expect(viewModel.isGenerating == false)
-    #expect(viewModel.streamingText.isEmpty)
-}
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages.first?.role == .assistant)
+        #expect(viewModel.messages.first?.content == "Hello world")
+        #expect(viewModel.isGenerating == false)
+        #expect(viewModel.streamingText.isEmpty)
+    }
 
-@Test @MainActor func stopGeneratingWithEmptyTextAppendsNothing() async {
-    let viewModel = ChatViewModel()
-    viewModel.isGenerating = true
-    viewModel.streamingText = ""
+    @Test func stopGeneratingWithEmptyTextAppendsNothing() async {
+        let viewModel = ChatViewModel()
+        viewModel.isGenerating = true
+        viewModel.streamingText = ""
 
-    await viewModel.stopGenerating()
+        await viewModel.stopGenerating()
 
-    #expect(viewModel.messages.isEmpty)
-    #expect(viewModel.isGenerating == false)
-}
+        #expect(viewModel.messages.isEmpty)
+        #expect(viewModel.isGenerating == false)
+    }
 
-// MARK: - Load Conversation
+    // MARK: - Load Conversation
 
-@Test @MainActor func loadConversationPopulatesMessages() throws {
-    let context = try makeContext()
-    let conversation = Conversation(title: "Test")
-    context.insert(conversation)
+    @Test func loadConversationPopulatesMessages() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-    let msg1 = Message(role: .user, content: "Hello")
-    msg1.conversation = conversation
-    conversation.messages.append(msg1)
+        let conversation = Conversation(title: "Test")
+        context.insert(conversation)
 
-    let msg2 = Message(role: .assistant, content: "Hi there")
-    msg2.conversation = conversation
-    conversation.messages.append(msg2)
-    try context.save()
+        let msg1 = Message(role: .user, content: "Hello")
+        msg1.conversation = conversation
+        conversation.messages.append(msg1)
 
-    let viewModel = ChatViewModel()
-    viewModel.modelContext = context
-    viewModel.loadConversation(conversation)
+        let msg2 = Message(role: .assistant, content: "Hi there")
+        msg2.conversation = conversation
+        conversation.messages.append(msg2)
+        try context.save()
 
-    #expect(viewModel.messages.count == 2)
-    #expect(viewModel.activeConversation?.id == conversation.id)
-    #expect(viewModel.messages.first?.role == .user)
-    #expect(viewModel.messages.last?.role == .assistant)
-}
+        let viewModel = ChatViewModel()
+        viewModel.modelContext = context
+        viewModel.loadConversation(conversation)
 
-// MARK: - Delete Conversation
+        #expect(viewModel.messages.count == 2)
+        #expect(viewModel.activeConversation?.id == conversation.id)
+        #expect(viewModel.messages.first?.role == .user)
+        #expect(viewModel.messages.last?.role == .assistant)
+    }
 
-@Test @MainActor func deleteConversationRemovesFromContext() throws {
-    let context = try makeContext()
-    let conversation = Conversation(title: "To Delete")
-    context.insert(conversation)
-    try context.save()
+    // MARK: - Delete Conversation
 
-    let viewModel = ChatViewModel()
-    viewModel.modelContext = context
+    @Test func deleteConversationRemovesFromContext() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-    viewModel.loadConversation(conversation)
-    viewModel.deleteConversation(conversation)
+        let conversation = Conversation(title: "To Delete")
+        context.insert(conversation)
+        try context.save()
 
-    #expect(viewModel.activeConversation == nil)
-    #expect(viewModel.messages.isEmpty)
+        let viewModel = ChatViewModel()
+        viewModel.modelContext = context
 
-    let descriptor = FetchDescriptor<Conversation>()
-    let remaining = try context.fetch(descriptor)
-    #expect(remaining.isEmpty)
-}
+        viewModel.loadConversation(conversation)
+        viewModel.deleteConversation(conversation)
 
-// MARK: - Clear Messages
+        #expect(viewModel.activeConversation == nil)
+        #expect(viewModel.messages.isEmpty)
 
-@Test @MainActor func clearMessagesDeletesConversationFromSwiftData() throws {
-    let context = try makeContext()
-    let conversation = Conversation(title: "Clear Me")
-    context.insert(conversation)
+        let descriptor = FetchDescriptor<Conversation>()
+        let remaining = try context.fetch(descriptor)
+        #expect(remaining.isEmpty)
+    }
 
-    let msg = Message(role: .user, content: "test")
-    msg.conversation = conversation
-    conversation.messages.append(msg)
-    try context.save()
+    // MARK: - Clear Messages
 
-    let viewModel = ChatViewModel()
-    viewModel.modelContext = context
-    viewModel.loadConversation(conversation)
+    @Test func clearMessagesDeletesConversationFromSwiftData() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-    viewModel.clearMessages()
+        let conversation = Conversation(title: "Clear Me")
+        context.insert(conversation)
 
-    #expect(viewModel.messages.isEmpty)
-    #expect(viewModel.activeConversation == nil)
+        let msg = Message(role: .user, content: "test")
+        msg.conversation = conversation
+        conversation.messages.append(msg)
+        try context.save()
 
-    let conversations = try context.fetch(FetchDescriptor<Conversation>())
-    #expect(conversations.isEmpty)
-}
+        let viewModel = ChatViewModel()
+        viewModel.modelContext = context
+        viewModel.loadConversation(conversation)
 
-// MARK: - Update Conversation Settings
+        viewModel.clearMessages()
 
-@Test @MainActor func updateSettingsCreatesConversation() throws {
-    let context = try makeContext()
-    let viewModel = ChatViewModel()
-    viewModel.modelContext = context
+        #expect(viewModel.messages.isEmpty)
+        #expect(viewModel.activeConversation == nil)
 
-    #expect(viewModel.activeConversation == nil)
+        let conversations = try context.fetch(FetchDescriptor<Conversation>())
+        #expect(conversations.isEmpty)
+    }
 
-    viewModel.updateConversationSettings(
-        systemPrompt: "You are a pirate.",
-        temperature: 0.5,
-        topP: 0.8
-    )
+    // MARK: - Update Conversation Settings
 
-    #expect(viewModel.activeConversation != nil)
-    #expect(viewModel.activeConversation?.systemPrompt == "You are a pirate.")
-    #expect(viewModel.activeConversation?.temperature == 0.5)
-    #expect(viewModel.activeConversation?.topP == 0.8)
-}
+    @Test func updateSettingsCreatesConversation() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-// MARK: - Conversation Config
+        let viewModel = ChatViewModel()
+        viewModel.modelContext = context
 
-@Test @MainActor func conversationConfigUsesConversationValues() throws {
-    let context = try makeContext()
-    let conversation = Conversation(
-        temperature: 0.3,
-        topP: 0.5
-    )
-    context.insert(conversation)
-    try context.save()
+        #expect(viewModel.activeConversation == nil)
 
-    let viewModel = ChatViewModel()
-    viewModel.modelContext = context
-    viewModel.loadConversation(conversation)
+        viewModel.updateConversationSettings(
+            systemPrompt: "You are a pirate.",
+            temperature: 0.5,
+            topP: 0.8
+        )
 
-    let config = viewModel.conversationConfig
-    #expect(config.temperature == 0.3)
-    #expect(config.topP == 0.5)
-}
+        #expect(viewModel.activeConversation != nil)
+        #expect(viewModel.activeConversation?.systemPrompt == "You are a pirate.")
+        #expect(viewModel.activeConversation?.temperature == 0.5)
+        #expect(viewModel.activeConversation?.topP == 0.8)
+    }
 
-@Test @MainActor func conversationConfigFallsBackToDefault() {
-    let viewModel = ChatViewModel()
-    let config = viewModel.conversationConfig
-    #expect(config.temperature == 0.7)
-    #expect(config.topP == 0.9)
+    // MARK: - Conversation Config
+
+    @Test func conversationConfigUsesConversationValues() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
+
+        let conversation = Conversation(
+            temperature: 0.3,
+            topP: 0.5
+        )
+        context.insert(conversation)
+        try context.save()
+
+        let viewModel = ChatViewModel()
+        viewModel.modelContext = context
+        viewModel.loadConversation(conversation)
+
+        let config = viewModel.conversationConfig
+        #expect(config.temperature == 0.3)
+        #expect(config.topP == 0.5)
+    }
+
+    @Test func conversationConfigFallsBackToDefault() {
+        let viewModel = ChatViewModel()
+        let config = viewModel.conversationConfig
+        #expect(config.temperature == 0.7)
+        #expect(config.topP == 0.9)
+    }
 }

--- a/HearthAITests/SwiftDataCascadeTests.swift
+++ b/HearthAITests/SwiftDataCascadeTests.swift
@@ -3,152 +3,149 @@ import SwiftData
 import Testing
 @testable import HearthAI
 
+@Suite(.serialized)
 @MainActor
-private func makeContext() throws -> ModelContext {
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
-    let container = try ModelContainer(
-        for: Conversation.self, Message.self, LocalModel.self,
-        configurations: config
-    )
-    return container.mainContext
-}
+struct SwiftDataCascadeTests {
 
-// MARK: - Cascade Delete
+    // MARK: - Cascade Delete
 
-@Test @MainActor
-func deletingConversationCascadesToMessages() throws {
-    let context = try makeContext()
+    @Test
+    func deletingConversationCascadesToMessages() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-    let conversation = Conversation(title: "Cascade Test")
-    context.insert(conversation)
+        let conversation = Conversation(title: "Cascade Test")
+        context.insert(conversation)
 
-    let msg1 = Message(role: .user, content: "Hello")
-    msg1.conversation = conversation
-    conversation.messages.append(msg1)
+        let msg1 = Message(role: .user, content: "Hello")
+        msg1.conversation = conversation
+        conversation.messages.append(msg1)
 
-    let msg2 = Message(role: .assistant, content: "Hi")
-    msg2.conversation = conversation
-    conversation.messages.append(msg2)
+        let msg2 = Message(role: .assistant, content: "Hi")
+        msg2.conversation = conversation
+        conversation.messages.append(msg2)
 
-    try context.save()
+        try context.save()
 
-    // Verify setup
-    let messagesBefore = try context.fetch(FetchDescriptor<Message>())
-    #expect(messagesBefore.count == 2)
+        // Verify setup
+        let messagesBefore = try context.fetch(FetchDescriptor<Message>())
+        #expect(messagesBefore.count == 2)
 
-    // Delete conversation — cascade should remove messages
-    context.delete(conversation)
-    try context.save()
+        // Delete conversation — cascade should remove messages
+        context.delete(conversation)
+        try context.save()
 
-    let conversations = try context.fetch(FetchDescriptor<Conversation>())
-    #expect(conversations.isEmpty)
+        let conversations = try context.fetch(FetchDescriptor<Conversation>())
+        #expect(conversations.isEmpty)
 
-    // After cascade, messages should have nil conversation
-    let messagesAfter = try context.fetch(FetchDescriptor<Message>())
-    for msg in messagesAfter {
-        #expect(msg.conversation == nil)
+        // After cascade, messages should have nil conversation
+        let messagesAfter = try context.fetch(FetchDescriptor<Message>())
+        for msg in messagesAfter {
+            #expect(msg.conversation == nil)
+        }
     }
-}
 
-// MARK: - Conversation Defaults
+    // MARK: - Conversation Defaults
 
-@Test @MainActor func conversationDefaultValues() throws {
-    let conversation = Conversation()
-    #expect(conversation.title == "New Conversation")
-    #expect(conversation.systemPrompt == "You are a helpful assistant.")
-    #expect(conversation.temperature == 0.7)
-    #expect(conversation.topP == 0.9)
-    #expect(conversation.contextLength == 2048)
-    #expect(conversation.modelId == nil)
-    #expect(conversation.messages.isEmpty)
-}
+    @Test func conversationDefaultValues() throws {
+        let conversation = Conversation()
+        #expect(conversation.title == "New Conversation")
+        #expect(conversation.systemPrompt == "You are a helpful assistant.")
+        #expect(conversation.temperature == 0.7)
+        #expect(conversation.topP == 0.9)
+        #expect(conversation.contextLength == 2048)
+        #expect(conversation.modelId == nil)
+        #expect(conversation.messages.isEmpty)
+    }
 
-@Test @MainActor func conversationCustomValues() throws {
-    let conversation = Conversation(
-        title: "Custom",
-        systemPrompt: "Be brief.",
-        temperature: 0.3,
-        topP: 0.5,
-        contextLength: 4096,
-        modelId: "test/model"
-    )
-    #expect(conversation.title == "Custom")
-    #expect(conversation.systemPrompt == "Be brief.")
-    #expect(conversation.temperature == 0.3)
-    #expect(conversation.topP == 0.5)
-    #expect(conversation.contextLength == 4096)
-    #expect(conversation.modelId == "test/model")
-}
+    @Test func conversationCustomValues() throws {
+        let conversation = Conversation(
+            title: "Custom",
+            systemPrompt: "Be brief.",
+            temperature: 0.3,
+            topP: 0.5,
+            contextLength: 4096,
+            modelId: "test/model"
+        )
+        #expect(conversation.title == "Custom")
+        #expect(conversation.systemPrompt == "Be brief.")
+        #expect(conversation.temperature == 0.3)
+        #expect(conversation.topP == 0.5)
+        #expect(conversation.contextLength == 4096)
+        #expect(conversation.modelId == "test/model")
+    }
 
-// MARK: - Message
+    // MARK: - Message
 
-@Test @MainActor func messageCreation() {
-    let msg = Message(role: .user, content: "Hello")
-    #expect(msg.role == .user)
-    #expect(msg.content == "Hello")
-    #expect(msg.conversation == nil)
-    #expect(msg.tokenCount == nil)
-}
+    @Test func messageCreation() {
+        let msg = Message(role: .user, content: "Hello")
+        #expect(msg.role == .user)
+        #expect(msg.content == "Hello")
+        #expect(msg.conversation == nil)
+        #expect(msg.tokenCount == nil)
+    }
 
-@Test @MainActor func messageWithTokenCount() {
-    let msg = Message(role: .assistant, content: "Hi", tokenCount: 42)
-    #expect(msg.tokenCount == 42)
-}
+    @Test func messageWithTokenCount() {
+        let msg = Message(role: .assistant, content: "Hi", tokenCount: 42)
+        #expect(msg.tokenCount == 42)
+    }
 
-// MARK: - Message Role
+    // MARK: - Message Role
 
-@Test func messageRoleRawValues() {
-    #expect(MessageRole.system.rawValue == "system")
-    #expect(MessageRole.user.rawValue == "user")
-    #expect(MessageRole.assistant.rawValue == "assistant")
-}
+    @Test func messageRoleRawValues() {
+        #expect(MessageRole.system.rawValue == "system")
+        #expect(MessageRole.user.rawValue == "user")
+        #expect(MessageRole.assistant.rawValue == "assistant")
+    }
 
-// MARK: - LocalModel
+    // MARK: - LocalModel
 
-@Test @MainActor func localModelAbsolutePath() throws {
-    let model = LocalModel(
-        id: "test/repo/model.gguf",
-        repoId: "test/repo",
-        fileName: "model.gguf",
-        displayName: "Test Model",
-        modelFamily: "Llama",
-        quantization: "Q4_K_M",
-        fileSizeBytes: 1_000_000,
-        localPath: "test_repo/model.gguf"
-    )
-    let expected = FileManager.modelsDirectory
-        .appendingPathComponent("test_repo/model.gguf")
-    #expect(model.absolutePath == expected)
-}
+    @Test func localModelAbsolutePath() throws {
+        let model = LocalModel(
+            id: "test/repo/model.gguf",
+            repoId: "test/repo",
+            fileName: "model.gguf",
+            displayName: "Test Model",
+            modelFamily: "Llama",
+            quantization: "Q4_K_M",
+            fileSizeBytes: 1_000_000,
+            localPath: "test_repo/model.gguf"
+        )
+        let expected = FileManager.modelsDirectory
+            .appendingPathComponent("test_repo/model.gguf")
+        #expect(model.absolutePath == expected)
+    }
 
-// MARK: - Multiple Conversations
+    // MARK: - Multiple Conversations
 
-@Test @MainActor
-func multipleConversationsIndependent() throws {
-    let context = try makeContext()
+    @Test
+    func multipleConversationsIndependent() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
 
-    let conv1 = Conversation(title: "First")
-    let conv2 = Conversation(title: "Second")
-    context.insert(conv1)
-    context.insert(conv2)
+        let conv1 = Conversation(title: "First")
+        let conv2 = Conversation(title: "Second")
+        context.insert(conv1)
+        context.insert(conv2)
 
-    let msg1 = Message(role: .user, content: "In first")
-    msg1.conversation = conv1
-    conv1.messages.append(msg1)
+        let msg1 = Message(role: .user, content: "In first")
+        msg1.conversation = conv1
+        conv1.messages.append(msg1)
 
-    let msg2 = Message(role: .user, content: "In second")
-    msg2.conversation = conv2
-    conv2.messages.append(msg2)
-    try context.save()
+        let msg2 = Message(role: .user, content: "In second")
+        msg2.conversation = conv2
+        conv2.messages.append(msg2)
+        try context.save()
 
-    // Delete first conversation
-    context.delete(conv1)
-    try context.save()
+        // Delete first conversation
+        context.delete(conv1)
+        try context.save()
 
-    // Second conversation should survive with its message
-    let conversations = try context.fetch(FetchDescriptor<Conversation>())
-    #expect(conversations.count == 1)
-    #expect(conversations.first?.title == "Second")
-    #expect(conversations.first?.messages.count == 1)
-    #expect(conversations.first?.messages.first?.content == "In second")
+        // Second conversation should survive with its message
+        let conversations = try context.fetch(FetchDescriptor<Conversation>())
+        #expect(conversations.count == 1)
+        #expect(conversations.first?.title == "Second")
+        #expect(conversations.first?.messages.count == 1)
+        #expect(conversations.first?.messages.first?.content == "In second")
+    }
 }

--- a/HearthAITests/TestModelContainer.swift
+++ b/HearthAITests/TestModelContainer.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftData
+@testable import HearthAI
+
+@MainActor
+enum TestModelContainer {
+    private static var _container: ModelContainer?
+
+    static var shared: ModelContainer {
+        get throws {
+            if let existing = _container {
+                return existing
+            }
+            let config = ModelConfiguration(isStoredInMemoryOnly: true)
+            let container = try ModelContainer(
+                for: Conversation.self, Message.self, LocalModel.self,
+                configurations: config
+            )
+            _container = container
+            return container
+        }
+    }
+
+    static func makeContext() throws -> ModelContext {
+        try shared.mainContext
+    }
+
+    static func cleanUp(_ context: ModelContext) throws {
+        try context.fetch(FetchDescriptor<Message>()).forEach { context.delete($0) }
+        try context.fetch(FetchDescriptor<Conversation>()).forEach { context.delete($0) }
+        try context.fetch(FetchDescriptor<LocalModel>()).forEach { context.delete($0) }
+        try context.save()
+    }
+}

--- a/Packages/LlamaCpp/Package.swift
+++ b/Packages/LlamaCpp/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "LlamaCpp",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v17), .macOS(.v14), .visionOS(.v1)],
     products: [
         .library(name: "LlamaCpp", targets: ["LlamaCpp"])
     ],

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,8 @@ options:
   bundleIdPrefix: ai.hearth
   deploymentTarget:
     iOS: "17.0"
+    macOS: "14.0"
+    visionOS: "1.0"
   xcodeVersion: "16.3"
   createIntermediateGroups: true
   generateEmptyDirectories: true
@@ -11,8 +13,11 @@ settings:
   base:
     SWIFT_VERSION: "5.9"
     IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    XROS_DEPLOYMENT_TARGET: "1.0"
     DEVELOPMENT_TEAM: ""
     EXCLUDED_ARCHS[sdk=iphonesimulator*]: "x86_64"
+    SUPPORTS_MACCATALYST: "NO"
 
 packages:
   LlamaCpp:
@@ -21,7 +26,7 @@ packages:
 targets:
   HearthAI:
     type: application
-    platform: iOS
+    supportedDestinations: [iOS, macOS, visionOS]
     sources:
       - path: HearthAI
     resources:
@@ -43,11 +48,28 @@ targets:
 
   HearthAITests:
     type: bundle.unit-test
-    platform: iOS
+    supportedDestinations: [iOS, macOS, visionOS]
     sources:
       - path: HearthAITests
     settings:
       base:
         GENERATE_INFOPLIST_FILE: true
+      configs:
+        debug:
+          TEST_HOST[sdk=macosx*]: "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI"
+          BUNDLE_LOADER[sdk=macosx*]: "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI"
+        release:
+          TEST_HOST[sdk=macosx*]: "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI"
+          BUNDLE_LOADER[sdk=macosx*]: "$(BUILT_PRODUCTS_DIR)/HearthAI.app/Contents/MacOS/HearthAI"
     dependencies:
       - target: HearthAI
+
+schemes:
+  HearthAI:
+    build:
+      targets:
+        HearthAI: all
+        HearthAITests: [test]
+    test:
+      targets:
+        - HearthAITests

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 #
-# Builds llama.cpp as an XCFramework for iOS device + simulator.
+# Builds llama.cpp as an XCFramework for iOS, macOS, and optionally visionOS.
 # Output: Packages/LlamaCpp/llama.xcframework/
+#
+# Usage:
+#   bash scripts/build-xcframework.sh                  # Build for all available SDKs
+#   bash scripts/build-xcframework.sh --platforms ios   # Build for iOS only
+#   bash scripts/build-xcframework.sh --platforms ios,macos
 #
 set -euo pipefail
 
@@ -12,6 +17,50 @@ OUTPUT_DIR="$PROJECT_ROOT/Packages/LlamaCpp"
 BUILD_DIR="$PROJECT_ROOT/build-llama"
 
 IOS_MIN_VERSION="17.0"
+MACOS_MIN_VERSION="14.0"
+VISIONOS_MIN_VERSION="1.0"
+
+# Parse --platforms argument
+REQUESTED_PLATFORMS=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --platforms)
+            REQUESTED_PLATFORMS="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Detect available SDKs
+has_sdk() {
+    xcrun --sdk "$1" --show-sdk-path &>/dev/null
+}
+
+BUILD_IOS=false
+BUILD_MACOS=false
+BUILD_VISIONOS=false
+
+if [ -n "$REQUESTED_PLATFORMS" ]; then
+    IFS=',' read -ra PLATFORMS <<< "$REQUESTED_PLATFORMS"
+    for platform in "${PLATFORMS[@]}"; do
+        case "$platform" in
+            ios) BUILD_IOS=true ;;
+            macos) BUILD_MACOS=true ;;
+            visionos) BUILD_VISIONOS=true ;;
+            all) BUILD_IOS=true; BUILD_MACOS=true; BUILD_VISIONOS=true ;;
+            *) echo "Unknown platform: $platform"; exit 1 ;;
+        esac
+    done
+else
+    # Auto-detect available SDKs
+    if has_sdk iphoneos; then BUILD_IOS=true; fi
+    if has_sdk macosx; then BUILD_MACOS=true; fi
+    if has_sdk xros; then BUILD_VISIONOS=true; fi
+fi
 
 if [ ! -d "$LLAMA_CPP_DIR" ]; then
     echo "Error: llama.cpp not found at $LLAMA_CPP_DIR"
@@ -22,6 +71,7 @@ fi
 echo "=== Building llama.cpp XCFramework ==="
 echo "Source: $LLAMA_CPP_DIR"
 echo "Output: $OUTPUT_DIR/llama.xcframework"
+echo "Platforms: iOS=$BUILD_IOS macOS=$BUILD_MACOS visionOS=$BUILD_VISIONOS"
 
 # Clean previous builds
 rm -rf "$BUILD_DIR"
@@ -42,37 +92,104 @@ COMMON_CMAKE_ARGS=(
     -DCMAKE_BUILD_TYPE=Release
 )
 
-# Build for iOS device (arm64)
-echo ""
-echo "--- Building for iOS device (arm64) ---"
-DEVICE_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
-cmake -B "$BUILD_DIR/ios-device" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
-    "${COMMON_CMAKE_ARGS[@]}" \
-    -DCMAKE_SYSTEM_NAME=iOS \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET="$IOS_MIN_VERSION" \
-    -DCMAKE_OSX_ARCHITECTURES="arm64" \
-    -DCMAKE_OSX_SYSROOT="$DEVICE_SDK" \
-    -DCMAKE_C_COMPILER="$(xcrun --sdk iphoneos --find clang)" \
-    -DCMAKE_CXX_COMPILER="$(xcrun --sdk iphoneos --find clang++)"
+NUM_CPUS="$(sysctl -n hw.ncpu)"
 
-cmake --build "$BUILD_DIR/ios-device" --config Release -j "$(sysctl -n hw.ncpu)"
+# --- iOS ---
+if [ "$BUILD_IOS" = true ]; then
+    echo ""
+    echo "--- Building for iOS device (arm64) ---"
+    DEVICE_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+    cmake -B "$BUILD_DIR/ios-device" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+        "${COMMON_CMAKE_ARGS[@]}" \
+        -DCMAKE_SYSTEM_NAME=iOS \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$IOS_MIN_VERSION" \
+        -DCMAKE_OSX_ARCHITECTURES="arm64" \
+        -DCMAKE_OSX_SYSROOT="$DEVICE_SDK" \
+        -DCMAKE_C_COMPILER="$(xcrun --sdk iphoneos --find clang)" \
+        -DCMAKE_CXX_COMPILER="$(xcrun --sdk iphoneos --find clang++)"
+    cmake --build "$BUILD_DIR/ios-device" --config Release -j "$NUM_CPUS"
 
-# Build for iOS simulator (arm64)
-echo ""
-echo "--- Building for iOS simulator (arm64) ---"
-SIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
-cmake -B "$BUILD_DIR/ios-simulator" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
-    "${COMMON_CMAKE_ARGS[@]}" \
-    -DCMAKE_SYSTEM_NAME=iOS \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET="$IOS_MIN_VERSION" \
-    -DCMAKE_OSX_ARCHITECTURES="arm64" \
-    -DCMAKE_OSX_SYSROOT="$SIMULATOR_SDK" \
-    -DCMAKE_C_COMPILER="$(xcrun --sdk iphonesimulator --find clang)" \
-    -DCMAKE_CXX_COMPILER="$(xcrun --sdk iphonesimulator --find clang++)" \
-    -DCMAKE_C_FLAGS="-target arm64-apple-ios${IOS_MIN_VERSION}-simulator" \
-    -DCMAKE_CXX_FLAGS="-target arm64-apple-ios${IOS_MIN_VERSION}-simulator"
+    echo ""
+    echo "--- Building for iOS simulator (arm64) ---"
+    SIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
+    cmake -B "$BUILD_DIR/ios-simulator" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+        "${COMMON_CMAKE_ARGS[@]}" \
+        -DCMAKE_SYSTEM_NAME=iOS \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$IOS_MIN_VERSION" \
+        -DCMAKE_OSX_ARCHITECTURES="arm64" \
+        -DCMAKE_OSX_SYSROOT="$SIMULATOR_SDK" \
+        -DCMAKE_C_COMPILER="$(xcrun --sdk iphonesimulator --find clang)" \
+        -DCMAKE_CXX_COMPILER="$(xcrun --sdk iphonesimulator --find clang++)" \
+        -DCMAKE_C_FLAGS="-target arm64-apple-ios${IOS_MIN_VERSION}-simulator" \
+        -DCMAKE_CXX_FLAGS="-target arm64-apple-ios${IOS_MIN_VERSION}-simulator"
+    cmake --build "$BUILD_DIR/ios-simulator" --config Release -j "$NUM_CPUS"
+fi
 
-cmake --build "$BUILD_DIR/ios-simulator" --config Release -j "$(sysctl -n hw.ncpu)"
+# --- macOS ---
+if [ "$BUILD_MACOS" = true ]; then
+    echo ""
+    echo "--- Building for macOS (arm64) ---"
+    MACOS_SDK=$(xcrun --sdk macosx --show-sdk-path)
+    cmake -B "$BUILD_DIR/macos-arm64" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+        "${COMMON_CMAKE_ARGS[@]}" \
+        -DCMAKE_SYSTEM_NAME=Darwin \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_MIN_VERSION" \
+        -DCMAKE_OSX_ARCHITECTURES="arm64" \
+        -DCMAKE_OSX_SYSROOT="$MACOS_SDK" \
+        -DCMAKE_C_COMPILER="$(xcrun --sdk macosx --find clang)" \
+        -DCMAKE_CXX_COMPILER="$(xcrun --sdk macosx --find clang++)"
+    cmake --build "$BUILD_DIR/macos-arm64" --config Release -j "$NUM_CPUS"
+
+    echo ""
+    echo "--- Building for macOS (x86_64) ---"
+    cmake -B "$BUILD_DIR/macos-x86_64" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+        "${COMMON_CMAKE_ARGS[@]}" \
+        -DGGML_METAL=OFF \
+        -DGGML_METAL_EMBED_LIBRARY=OFF \
+        -DCMAKE_SYSTEM_NAME=Darwin \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_MIN_VERSION" \
+        -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+        -DCMAKE_OSX_SYSROOT="$MACOS_SDK" \
+        -DCMAKE_C_COMPILER="$(xcrun --sdk macosx --find clang)" \
+        -DCMAKE_CXX_COMPILER="$(xcrun --sdk macosx --find clang++)"
+    cmake --build "$BUILD_DIR/macos-x86_64" --config Release -j "$NUM_CPUS"
+fi
+
+# --- visionOS ---
+if [ "$BUILD_VISIONOS" = true ]; then
+    if has_sdk xros; then
+        echo ""
+        echo "--- Building for visionOS device (arm64) ---"
+        VISIONOS_SDK=$(xcrun --sdk xros --show-sdk-path)
+        cmake -B "$BUILD_DIR/visionos-device" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+            "${COMMON_CMAKE_ARGS[@]}" \
+            -DCMAKE_SYSTEM_NAME=visionOS \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$VISIONOS_MIN_VERSION" \
+            -DCMAKE_OSX_ARCHITECTURES="arm64" \
+            -DCMAKE_OSX_SYSROOT="$VISIONOS_SDK" \
+            -DCMAKE_C_COMPILER="$(xcrun --sdk xros --find clang)" \
+            -DCMAKE_CXX_COMPILER="$(xcrun --sdk xros --find clang++)"
+        cmake --build "$BUILD_DIR/visionos-device" --config Release -j "$NUM_CPUS"
+
+        echo ""
+        echo "--- Building for visionOS simulator (arm64) ---"
+        VISIONOS_SIM_SDK=$(xcrun --sdk xrsimulator --show-sdk-path)
+        cmake -B "$BUILD_DIR/visionos-simulator" -S "$LLAMA_CPP_DIR" -G "Unix Makefiles" \
+            "${COMMON_CMAKE_ARGS[@]}" \
+            -DCMAKE_SYSTEM_NAME=visionOS \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$VISIONOS_MIN_VERSION" \
+            -DCMAKE_OSX_ARCHITECTURES="arm64" \
+            -DCMAKE_OSX_SYSROOT="$VISIONOS_SIM_SDK" \
+            -DCMAKE_C_COMPILER="$(xcrun --sdk xrsimulator --find clang)" \
+            -DCMAKE_CXX_COMPILER="$(xcrun --sdk xrsimulator --find clang++)" \
+            -DCMAKE_C_FLAGS="-target arm64-apple-xros${VISIONOS_MIN_VERSION}-simulator" \
+            -DCMAKE_CXX_FLAGS="-target arm64-apple-xros${VISIONOS_MIN_VERSION}-simulator"
+        cmake --build "$BUILD_DIR/visionos-simulator" --config Release -j "$NUM_CPUS"
+    else
+        echo "Warning: visionOS SDK not found, skipping visionOS build"
+        BUILD_VISIONOS=false
+    fi
+fi
 
 # Find and collect static libraries
 echo ""
@@ -91,10 +208,20 @@ collect_libs() {
     done
 }
 
-collect_libs "$BUILD_DIR/ios-device" "$BUILD_DIR/libs/device"
-collect_libs "$BUILD_DIR/ios-simulator" "$BUILD_DIR/libs/simulator"
+if [ "$BUILD_IOS" = true ]; then
+    collect_libs "$BUILD_DIR/ios-device" "$BUILD_DIR/libs/ios-device"
+    collect_libs "$BUILD_DIR/ios-simulator" "$BUILD_DIR/libs/ios-simulator"
+fi
+if [ "$BUILD_MACOS" = true ]; then
+    collect_libs "$BUILD_DIR/macos-arm64" "$BUILD_DIR/libs/macos-arm64"
+    collect_libs "$BUILD_DIR/macos-x86_64" "$BUILD_DIR/libs/macos-x86_64"
+fi
+if [ "$BUILD_VISIONOS" = true ]; then
+    collect_libs "$BUILD_DIR/visionos-device" "$BUILD_DIR/libs/visionos-device"
+    collect_libs "$BUILD_DIR/visionos-simulator" "$BUILD_DIR/libs/visionos-simulator"
+fi
 
-# Merge all static libs into a single archive per platform
+# Merge all static libs into a single archive per platform slice
 echo ""
 echo "--- Merging into single static library per platform ---"
 
@@ -121,8 +248,27 @@ merge_libs() {
     echo "  Created: $output ($(du -h "$output" | cut -f1))"
 }
 
-merge_libs "device"
-merge_libs "simulator"
+if [ "$BUILD_IOS" = true ]; then
+    merge_libs "ios-device"
+    merge_libs "ios-simulator"
+fi
+if [ "$BUILD_MACOS" = true ]; then
+    merge_libs "macos-arm64"
+    merge_libs "macos-x86_64"
+
+    # Create universal macOS binary with lipo
+    echo "  Creating universal macOS binary (arm64 + x86_64)"
+    mkdir -p "$BUILD_DIR/merged/macos-universal"
+    lipo -create \
+        "$BUILD_DIR/merged/macos-arm64/libllama_all.a" \
+        "$BUILD_DIR/merged/macos-x86_64/libllama_all.a" \
+        -output "$BUILD_DIR/merged/macos-universal/libllama_all.a"
+    echo "  Created: $BUILD_DIR/merged/macos-universal/libllama_all.a ($(du -h "$BUILD_DIR/merged/macos-universal/libllama_all.a" | cut -f1))"
+fi
+if [ "$BUILD_VISIONOS" = true ]; then
+    merge_libs "visionos-device"
+    merge_libs "visionos-simulator"
+fi
 
 # Collect headers
 echo ""
@@ -156,11 +302,38 @@ MODULEMAP
 # Create XCFramework
 echo ""
 echo "--- Creating XCFramework ---"
+
+XCFRAMEWORK_ARGS=()
+if [ "$BUILD_IOS" = true ]; then
+    XCFRAMEWORK_ARGS+=(
+        -library "$BUILD_DIR/merged/ios-device/libllama_all.a"
+        -headers "$HEADERS_DIR"
+        -library "$BUILD_DIR/merged/ios-simulator/libllama_all.a"
+        -headers "$HEADERS_DIR"
+    )
+fi
+if [ "$BUILD_MACOS" = true ]; then
+    XCFRAMEWORK_ARGS+=(
+        -library "$BUILD_DIR/merged/macos-universal/libllama_all.a"
+        -headers "$HEADERS_DIR"
+    )
+fi
+if [ "$BUILD_VISIONOS" = true ]; then
+    XCFRAMEWORK_ARGS+=(
+        -library "$BUILD_DIR/merged/visionos-device/libllama_all.a"
+        -headers "$HEADERS_DIR"
+        -library "$BUILD_DIR/merged/visionos-simulator/libllama_all.a"
+        -headers "$HEADERS_DIR"
+    )
+fi
+
+if [ ${#XCFRAMEWORK_ARGS[@]} -eq 0 ]; then
+    echo "Error: No platforms were built"
+    exit 1
+fi
+
 xcodebuild -create-xcframework \
-    -library "$BUILD_DIR/merged/device/libllama_all.a" \
-    -headers "$HEADERS_DIR" \
-    -library "$BUILD_DIR/merged/simulator/libllama_all.a" \
-    -headers "$HEADERS_DIR" \
+    "${XCFRAMEWORK_ARGS[@]}" \
     -output "$OUTPUT_DIR/llama.xcframework"
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #29

- Extends Hearth AI from iPhone-only to support **iPad** (sidebar navigation), **macOS** (native app with Settings scene), and **visionOS**
- Builds multi-platform XCFramework with iOS, macOS (universal arm64+x86_64), and visionOS slices via `--platforms` flag
- Replaces all UIKit-only APIs with cross-platform alternatives using `#if canImport(UIKit)` / `#if os(macOS)` conditional compilation
- Adds `NavigationSplitView` sidebar layout for iPad/macOS while preserving `TabView` for iPhone compact
- Fixes SwiftData test stability on macOS with shared `TestModelContainer` singleton
- Splits CI into parallel iOS and macOS build-and-test jobs

## Key Changes

- **`project.yml`**: `supportedDestinations: [iOS, macOS, visionOS]`, macOS TEST_HOST config, explicit scheme
- **`scripts/build-xcframework.sh`**: Full rewrite supporting `--platforms ios,macos,visionos` flag, universal macOS binary via `lipo`
- **`ContentView.swift`**: Adaptive layout — `NavigationSplitView` for regular size class, `TabView` for compact
- **`InferenceService.swift`**: macOS memory pressure monitoring via `DispatchSource`
- **`DeviceCapability.swift`**: Platform-aware memory detection (macOS uses `physicalMemory`)
- **`MessageBubble.swift`**: Cross-platform clipboard (`NSPasteboard` / `UIPasteboard`)
- **`TestModelContainer.swift`**: New shared singleton preventing macOS test host crashes

## Test Plan

- [x] All 68 tests pass on iOS Simulator
- [x] All 68 tests pass on macOS
- [x] Zero SwiftLint violations (38 files)
- [x] iOS and macOS builds succeed
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)