### PR TITLE
Add document import and local Q&A with on-device inference

### DIFF
--- a/HearthAI.xcodeproj/project.pbxproj
+++ b/HearthAI.xcodeproj/project.pbxproj
@@ -14,8 +14,10 @@
 		0BE4B41958A063A6C03F361B /* LocalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE68C23BD50C2CE6816C8530 /* LocalModel.swift */; };
 		113B66D2FA42EE2D775C50EF /* ChatSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AC4C60DF7E5535303E6452 /* ChatSettingsSheet.swift */; };
 		13BCF566B384257B26B019B3 /* SharedModelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D85805E3D380661427244EB /* SharedModelInfo.swift */; };
+		14E94DB37B49BAED67DCEAA7 /* DocumentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B42E2F08E2C9CC73214C8F /* DocumentDetailView.swift */; };
 		155F299FF7740D656A56B321 /* FeaturedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373240DBA631EE03834240EE /* FeaturedModel.swift */; };
 		17C2529672146A86D835ACAB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405D1CA44865EBE10F089668 /* ContentView.swift */; };
+		20678580AC3CF4F960C0EF6C /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9A17825EBCC47C4EE3D09 /* Document.swift */; };
 		277EC11BB99B21DB654150CC /* FeaturedModels.json in Resources */ = {isa = PBXBuildFile; fileRef = 7FA5D99754391A1FBEBEECBE /* FeaturedModels.json */; };
 		2C907C7396B9C17E1E17B1D7 /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D7A6B104010F923B7AB439 /* ShareView.swift */; };
 		2DD66AD82F61D4C10754D647 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17591C8661B8C4D1FDF88DE6 /* ShareViewController.swift */; };
@@ -25,9 +27,12 @@
 		3EAFF404AA53A5508DD02E35 /* TranslateTextIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6DEA772E16322B603B8309 /* TranslateTextIntent.swift */; };
 		3EC1B05C4AAF3F0C5AC05A30 /* ThermalMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C3075948717C3F9278DAD5 /* ThermalMonitor.swift */; };
 		3ECF7975DBD75B903E5EB857 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005D99CFD00EACE9FC742BC6 /* Message.swift */; };
+		4155E70AF69B2FC128572BEE /* DocumentPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D6E2E7D7848264E97EC54 /* DocumentPickerSheet.swift */; };
 		622062D7C8B261390A04FBA9 /* AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943464BE9F3E3817391F7A53 /* AppGroupConstants.swift */; };
 		639A044C1753FF1410811004 /* SharedRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7974F4AB6E5FD1F7020ACC /* SharedRequestHandler.swift */; };
+		6B2EF1314D0BBFCCBB7D062F /* DocumentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29FD89E362F558F41CEC691 /* DocumentsView.swift */; };
 		6B996D420BF5178D6ABC0AAF /* SharedInferenceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B660F2E8E97C928DD84ED71 /* SharedInferenceRequest.swift */; };
+		72A3D422293A97DA1D59BBE0 /* ChunkSelectorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA0B5195965A7A2E274B23A /* ChunkSelectorService.swift */; };
 		73CE4807A74F2AD7AC5B03A0 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = C988D7AB8665E8A6DFE87363 /* MessageBubble.swift */; };
 		7651BC5F24C30D0D44C48067 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E60EC72A2F0D58CA567D91D /* Conversation.swift */; };
 		78CA7BCF236B2498F77B7031 /* InferenceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1307661B3414B71F26366B8 /* InferenceConfiguration.swift */; };
@@ -37,6 +42,7 @@
 		8747ADDE6914933ED42C70A5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B5F72E3F69C00CEDE45E8C /* Constants.swift */; };
 		8A5B36588755EFFB4BEA89EF /* HuggingFaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31143EB8502183C8C805EDD /* HuggingFaceTests.swift */; };
 		8A78CB0370790965C3B33F2D /* HuggingFaceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A6F0DD2CF3C5F44E0C0190 /* HuggingFaceAPI.swift */; };
+		8B1AC9BF9971F0C7BF7BBB9E /* DocumentChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F08D71E4F9007C80ACDFD4 /* DocumentChunk.swift */; };
 		910A8C1FFD6C00FCB79D6E0D /* SwiftDataCascadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD6808C0B4D60CE08267A51 /* SwiftDataCascadeTests.swift */; };
 		94D339C97159BD1FE1910F02 /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276338C3C40E6E21B3AF5F5 /* DownloadState.swift */; };
 		988A1466A3BB010F3686F065 /* HearthAIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E903921FAA09285C7EC06626 /* HearthAIApp.swift */; };
@@ -45,22 +51,28 @@
 		A63768214BABE2B98203900A /* FeaturedModelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C845EBC43D03C4AAB4C3E312 /* FeaturedModelDetailView.swift */; };
 		A6E9B6197D48DAC4014311FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1EA4C3783A128CC1C2D30817 /* Assets.xcassets */; };
 		A8F8386F0CC30F0FDEB0FA60 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9160C707541C1A6967F91F9 /* ModelPickerSheet.swift */; };
+		ACC1BA53A960391E7964E7A6 /* TextExtractorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE5B7A251D3B6378AB662EA /* TextExtractorService.swift */; };
 		B11413DBB7BF1AFF9AE57E1D /* HearthAIShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 05AEAAA0F63913A403034097 /* HearthAIShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B2AF8B80B10D5264076FAD20 /* SummarizeTextIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A7DF7A43402CED188B49 /* SummarizeTextIntent.swift */; };
 		B978D5031CC9F31BB9590F6B /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46AE8CED565F05123B55EE96 /* LibraryView.swift */; };
 		BC87F36961BE0BED3EAA6D7C /* SharedInferenceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B660F2E8E97C928DD84ED71 /* SharedInferenceRequest.swift */; };
+		C1864805E1FA7225AEF232C6 /* ChunkSelectorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED6A6FA7704A2242A250446 /* ChunkSelectorServiceTests.swift */; };
 		C23EDD8253AC5BFB0D8D060A /* ConversationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79397D1BF9F8D57724511993 /* ConversationListView.swift */; };
 		C7F2A3D0417981686B4E3052 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397BD3F6A93E6069059BBBBF /* AppState.swift */; };
 		C8F1F74159FBEA232A3ADA84 /* SharedModelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D85805E3D380661427244EB /* SharedModelInfo.swift */; };
 		CBB8F9486DF5B9A8F6F350A7 /* DeviceCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79297A2500C2BFE5F893531F /* DeviceCapability.swift */; };
+		CD0AD408F006860CB7F0C3E9 /* ChunkingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333A57D575AEC2A67BA09B2A /* ChunkingServiceTests.swift */; };
 		CDB4579A512B12F942C6E768 /* ModelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */; };
 		CE92A1FB39AD10CF859706C5 /* TestModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80C3E2B605DDA7CD3DF5A1E /* TestModelContainer.swift */; };
 		DFE0909D9533627F1E418FED /* DownloadServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B7417DFD3FFE4FD4E79869 /* DownloadServiceTests.swift */; };
 		E2C2286EA5EE4654FEDBAB13 /* HearthShortcutsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3F54443400BD54DD98CF88 /* HearthShortcutsProvider.swift */; };
 		E54D3B77567891D761E4A4F1 /* SharedModelSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478341E3D3B3E805B83AB5FF /* SharedModelSync.swift */; };
+		E6C9FE639A22FB4521592256 /* DocumentImportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72772F3930C5C52045689935 /* DocumentImportViewModel.swift */; };
+		E8354755DBAA1A2A0F044B65 /* DocumentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8173BBECC60148FA3A873AB /* DocumentModelTests.swift */; };
 		EDCB9DFEFD505357908BDAE4 /* SharedRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E997B6BE59E4E66F8A2A619B /* SharedRequestView.swift */; };
 		EF385FE0755585B7C27D956B /* RewriteTextIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F188207F9C44341F0DC70E52 /* RewriteTextIntent.swift */; };
 		F09B9F855596430552F5A8FE /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890BDB102F2FE40261F5A508 /* ChatViewModel.swift */; };
+		F1A7D42C5A0E220569D7EB2B /* ChunkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE84EAC9AB368993AFA36E7E /* ChunkingService.swift */; };
 		F1AD3F2C8048B14FC787BF4D /* FileManager+AppSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7FB411EA3CC770171848E7 /* FileManager+AppSupport.swift */; };
 		F25378990BEE3F1FCACD6897 /* AskHearthIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C82B65ABF1D3EFF7D91BF28 /* AskHearthIntent.swift */; };
 		F6D7E75B6E97C47D01634F4B /* InferenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D431ED0C8BB31AC0B5AA80D /* InferenceService.swift */; };
@@ -114,9 +126,11 @@
 		23FA0F0505A852036347ADD6 /* ModelStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelStoreViewModel.swift; sourceTree = "<group>"; };
 		29482A421FB1811401D6034E /* HearthAITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HearthAITests.swift; sourceTree = "<group>"; };
 		29FE3C51741B039227B6DE50 /* LocalModelEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelEntity.swift; sourceTree = "<group>"; };
+		2ED6A6FA7704A2242A250446 /* ChunkSelectorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkSelectorServiceTests.swift; sourceTree = "<group>"; };
 		315875C2BEE8F04B1653AEA1 /* ModelStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelStoreView.swift; sourceTree = "<group>"; };
 		31D180D8E597FDFD2F857CFD /* ModelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailView.swift; sourceTree = "<group>"; };
 		3308EA296BE9611CEE76B736 /* HearthAITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HearthAITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		333A57D575AEC2A67BA09B2A /* ChunkingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkingServiceTests.swift; sourceTree = "<group>"; };
 		36D7A6B104010F923B7AB439 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
 		373240DBA631EE03834240EE /* FeaturedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedModel.swift; sourceTree = "<group>"; };
 		397BD3F6A93E6069059BBBBF /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -132,6 +146,7 @@
 		4D9CB851129C2E57E58FF870 /* HFModelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HFModelInfo.swift; sourceTree = "<group>"; };
 		5D1D6195ED7695130A8D335C /* HearthAI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HearthAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E60EC72A2F0D58CA567D91D /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
+		72772F3930C5C52045689935 /* DocumentImportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentImportViewModel.swift; sourceTree = "<group>"; };
 		79297A2500C2BFE5F893531F /* DeviceCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCapability.swift; sourceTree = "<group>"; };
 		79397D1BF9F8D57724511993 /* ConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListView.swift; sourceTree = "<group>"; };
 		7FA5D99754391A1FBEBEECBE /* FeaturedModels.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FeaturedModels.json; sourceTree = "<group>"; };
@@ -139,21 +154,28 @@
 		890BDB102F2FE40261F5A508 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		8D68E1B22F6633BA12A90545 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8DD6808C0B4D60CE08267A51 /* SwiftDataCascadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataCascadeTests.swift; sourceTree = "<group>"; };
+		8EA9A17825EBCC47C4EE3D09 /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		9392A7DF7A43402CED188B49 /* SummarizeTextIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeTextIntent.swift; sourceTree = "<group>"; };
 		943464BE9F3E3817391F7A53 /* AppGroupConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupConstants.swift; sourceTree = "<group>"; };
 		99C3075948717C3F9278DAD5 /* ThermalMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalMonitor.swift; sourceTree = "<group>"; };
 		9C82B65ABF1D3EFF7D91BF28 /* AskHearthIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskHearthIntent.swift; sourceTree = "<group>"; };
 		9D85805E3D380661427244EB /* SharedModelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedModelInfo.swift; sourceTree = "<group>"; };
 		9FCE4215B2189C14F0DC7EB8 /* SharedTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTypesTests.swift; sourceTree = "<group>"; };
+		A29FD89E362F558F41CEC691 /* DocumentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsView.swift; sourceTree = "<group>"; };
+		AE84EAC9AB368993AFA36E7E /* ChunkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkingService.swift; sourceTree = "<group>"; };
 		B1A6F0DD2CF3C5F44E0C0190 /* HuggingFaceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPI.swift; sourceTree = "<group>"; };
 		B6B5F72E3F69C00CEDE45E8C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		B8173BBECC60148FA3A873AB /* DocumentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModelTests.swift; sourceTree = "<group>"; };
 		BE7974F4AB6E5FD1F7020ACC /* SharedRequestHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedRequestHandler.swift; sourceTree = "<group>"; };
+		BEA0B5195965A7A2E274B23A /* ChunkSelectorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkSelectorService.swift; sourceTree = "<group>"; };
 		C31143EB8502183C8C805EDD /* HuggingFaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceTests.swift; sourceTree = "<group>"; };
 		C845EBC43D03C4AAB4C3E312 /* FeaturedModelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedModelDetailView.swift; sourceTree = "<group>"; };
 		C9160C707541C1A6967F91F9 /* ModelPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPickerSheet.swift; sourceTree = "<group>"; };
 		C988D7AB8665E8A6DFE87363 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		CD7FB411EA3CC770171848E7 /* FileManager+AppSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+AppSupport.swift"; sourceTree = "<group>"; };
 		CE68C23BD50C2CE6816C8530 /* LocalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModel.swift; sourceTree = "<group>"; };
+		D7F08D71E4F9007C80ACDFD4 /* DocumentChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentChunk.swift; sourceTree = "<group>"; };
+		D9B42E2F08E2C9CC73214C8F /* DocumentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentDetailView.swift; sourceTree = "<group>"; };
 		E0E39895107391568ACB967A /* DeviceCapabilityEdgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCapabilityEdgeTests.swift; sourceTree = "<group>"; };
 		E1307661B3414B71F26366B8 /* InferenceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceConfiguration.swift; sourceTree = "<group>"; };
 		E80C3E2B605DDA7CD3DF5A1E /* TestModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelContainer.swift; sourceTree = "<group>"; };
@@ -163,6 +185,8 @@
 		EA5163E146981BFA10057E46 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		EDB65F51015E640BC7FB01B1 /* IntentInferenceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentInferenceHelper.swift; sourceTree = "<group>"; };
 		F188207F9C44341F0DC70E52 /* RewriteTextIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewriteTextIntent.swift; sourceTree = "<group>"; };
+		F61D6E2E7D7848264E97EC54 /* DocumentPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerSheet.swift; sourceTree = "<group>"; };
+		FAE5B7A251D3B6378AB662EA /* TextExtractorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExtractorService.swift; sourceTree = "<group>"; };
 		FE3F54443400BD54DD98CF88 /* HearthShortcutsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HearthShortcutsProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -188,6 +212,17 @@
 			path = Inference;
 			sourceTree = "<group>";
 		};
+		1289453E93772036A32CB4B5 /* Documents */ = {
+			isa = PBXGroup;
+			children = (
+				D9B42E2F08E2C9CC73214C8F /* DocumentDetailView.swift */,
+				72772F3930C5C52045689935 /* DocumentImportViewModel.swift */,
+				F61D6E2E7D7848264E97EC54 /* DocumentPickerSheet.swift */,
+				A29FD89E362F558F41CEC691 /* DocumentsView.swift */,
+			);
+			path = Documents;
+			sourceTree = "<group>";
+		};
 		17BC82A6EC84F776D1F486C6 /* Library */ = {
 			isa = PBXGroup;
 			children = (
@@ -200,7 +235,10 @@
 			isa = PBXGroup;
 			children = (
 				1E0A2225A6C6EDBB50BA8EC2 /* ChatViewModelPersistenceTests.swift */,
+				333A57D575AEC2A67BA09B2A /* ChunkingServiceTests.swift */,
+				2ED6A6FA7704A2242A250446 /* ChunkSelectorServiceTests.swift */,
 				E0E39895107391568ACB967A /* DeviceCapabilityEdgeTests.swift */,
+				B8173BBECC60148FA3A873AB /* DocumentModelTests.swift */,
 				05B7417DFD3FFE4FD4E79869 /* DownloadServiceTests.swift */,
 				29482A421FB1811401D6034E /* HearthAITests.swift */,
 				C31143EB8502183C8C805EDD /* HuggingFaceTests.swift */,
@@ -215,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				478341E3D3B3E805B83AB5FF /* SharedModelSync.swift */,
+				2D89E90D424B5C90473230EA /* DocumentProcessing */,
 				3F2C674A23C0DC92FA53DF35 /* Download */,
 				2F0C272745E1A7BF756F96A4 /* HuggingFace */,
 				00F89149905095BC15B06495 /* Inference */,
@@ -240,6 +279,16 @@
 				17591C8661B8C4D1FDF88DE6 /* ShareViewController.swift */,
 			);
 			path = "HearthAI ShareExtension";
+			sourceTree = "<group>";
+		};
+		2D89E90D424B5C90473230EA /* DocumentProcessing */ = {
+			isa = PBXGroup;
+			children = (
+				AE84EAC9AB368993AFA36E7E /* ChunkingService.swift */,
+				BEA0B5195965A7A2E274B23A /* ChunkSelectorService.swift */,
+				FAE5B7A251D3B6378AB662EA /* TextExtractorService.swift */,
+			);
+			path = DocumentProcessing;
 			sourceTree = "<group>";
 		};
 		2F0C272745E1A7BF756F96A4 /* HuggingFace */ = {
@@ -413,6 +462,8 @@
 			isa = PBXGroup;
 			children = (
 				5E60EC72A2F0D58CA567D91D /* Conversation.swift */,
+				8EA9A17825EBCC47C4EE3D09 /* Document.swift */,
+				D7F08D71E4F9007C80ACDFD4 /* DocumentChunk.swift */,
 				CE68C23BD50C2CE6816C8530 /* LocalModel.swift */,
 				005D99CFD00EACE9FC742BC6 /* Message.swift */,
 			);
@@ -439,6 +490,7 @@
 			children = (
 				85B7E1C543C7C6B9F0A76450 /* AppIntents */,
 				31B438CE7A75F716E8F1F209 /* Chat */,
+				1289453E93772036A32CB4B5 /* Documents */,
 				17BC82A6EC84F776D1F486C6 /* Library */,
 				C3CEF0A248931D5C41290483 /* ModelStore */,
 				74345F7F3A5700DF2291083B /* Settings */,
@@ -574,11 +626,19 @@
 				113B66D2FA42EE2D775C50EF /* ChatSettingsSheet.swift in Sources */,
 				03A3AF701474977398790AA6 /* ChatView.swift in Sources */,
 				F09B9F855596430552F5A8FE /* ChatViewModel.swift in Sources */,
+				72A3D422293A97DA1D59BBE0 /* ChunkSelectorService.swift in Sources */,
+				F1A7D42C5A0E220569D7EB2B /* ChunkingService.swift in Sources */,
 				8747ADDE6914933ED42C70A5 /* Constants.swift in Sources */,
 				17C2529672146A86D835ACAB /* ContentView.swift in Sources */,
 				7651BC5F24C30D0D44C48067 /* Conversation.swift in Sources */,
 				C23EDD8253AC5BFB0D8D060A /* ConversationListView.swift in Sources */,
 				CBB8F9486DF5B9A8F6F350A7 /* DeviceCapability.swift in Sources */,
+				20678580AC3CF4F960C0EF6C /* Document.swift in Sources */,
+				8B1AC9BF9971F0C7BF7BBB9E /* DocumentChunk.swift in Sources */,
+				14E94DB37B49BAED67DCEAA7 /* DocumentDetailView.swift in Sources */,
+				E6C9FE639A22FB4521592256 /* DocumentImportViewModel.swift in Sources */,
+				4155E70AF69B2FC128572BEE /* DocumentPickerSheet.swift in Sources */,
+				6B2EF1314D0BBFCCBB7D062F /* DocumentsView.swift in Sources */,
 				FF28A34B4C8D7ACEBC31AEBA /* DownloadService.swift in Sources */,
 				94D339C97159BD1FE1910F02 /* DownloadState.swift in Sources */,
 				155F299FF7740D656A56B321 /* FeaturedModel.swift in Sources */,
@@ -609,6 +669,7 @@
 				639A044C1753FF1410811004 /* SharedRequestHandler.swift in Sources */,
 				EDCB9DFEFD505357908BDAE4 /* SharedRequestView.swift in Sources */,
 				B2AF8B80B10D5264076FAD20 /* SummarizeTextIntent.swift in Sources */,
+				ACC1BA53A960391E7964E7A6 /* TextExtractorService.swift in Sources */,
 				3EC1B05C4AAF3F0C5AC05A30 /* ThermalMonitor.swift in Sources */,
 				3EAFF404AA53A5508DD02E35 /* TranslateTextIntent.swift in Sources */,
 			);
@@ -631,7 +692,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				04A7C29DA16524A6206C4CE6 /* ChatViewModelPersistenceTests.swift in Sources */,
+				C1864805E1FA7225AEF232C6 /* ChunkSelectorServiceTests.swift in Sources */,
+				CD0AD408F006860CB7F0C3E9 /* ChunkingServiceTests.swift in Sources */,
 				9DBDB26696C27EDB37990992 /* DeviceCapabilityEdgeTests.swift in Sources */,
+				E8354755DBAA1A2A0F044B65 /* DocumentModelTests.swift in Sources */,
 				DFE0909D9533627F1E418FED /* DownloadServiceTests.swift in Sources */,
 				FDF5740963252281A3030A24 /* HearthAITests.swift in Sources */,
 				8A5B36588755EFFB4BEA89EF /* HuggingFaceTests.swift in Sources */,

--- a/HearthAI/App/ContentView.swift
+++ b/HearthAI/App/ContentView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum NavigationItem: Hashable {
-    case chat, models, library, settings
+    case chat, documents, models, library, settings
 }
 
 struct ContentView: View {
@@ -28,6 +28,9 @@ struct TabContentView: View {
             ChatView()
                 .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }
 
+            DocumentsView()
+                .tabItem { Label("Documents", systemImage: "doc.text.magnifyingglass") }
+
             ModelStoreView()
                 .tabItem { Label("Models", systemImage: "square.grid.2x2") }
 
@@ -48,6 +51,8 @@ struct SidebarContentView: View {
             List(selection: $selection) {
                 Label("Chat", systemImage: "bubble.left.and.bubble.right")
                     .tag(NavigationItem.chat)
+                Label("Documents", systemImage: "doc.text.magnifyingglass")
+                    .tag(NavigationItem.documents)
                 Label("Models", systemImage: "square.grid.2x2")
                     .tag(NavigationItem.models)
                 Label("Library", systemImage: "internaldrive")
@@ -60,6 +65,8 @@ struct SidebarContentView: View {
             switch selection {
             case .chat:
                 ChatView()
+            case .documents:
+                DocumentsView()
             case .models:
                 ModelStoreView()
             case .library:

--- a/HearthAI/App/HearthAIApp.swift
+++ b/HearthAI/App/HearthAIApp.swift
@@ -11,7 +11,8 @@ struct HearthAIApp: App {
     init() {
         do {
             modelContainer = try ModelContainer(
-                for: LocalModel.self, Conversation.self, Message.self
+                for: LocalModel.self, Conversation.self, Message.self,
+                Document.self, DocumentChunk.self
             )
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")

--- a/HearthAI/Features/Chat/ChatView.swift
+++ b/HearthAI/Features/Chat/ChatView.swift
@@ -10,6 +10,7 @@ struct ChatView: View {
     @State private var showModelPicker = false
     @State private var showConversations = false
     @State private var showChatSettings = false
+    @State private var showDocumentPicker = false
 
     var body: some View {
         NavigationStack {
@@ -17,6 +18,9 @@ struct ChatView: View {
                 messageList
                 if appState.thermalMonitor.shouldWarnUser {
                     thermalWarning
+                }
+                if viewModel.attachedDocument != nil {
+                    documentBadge
                 }
                 inputBar
             }
@@ -33,6 +37,11 @@ struct ChatView: View {
             }
             .sheet(isPresented: $showChatSettings) {
                 chatSettingsSheet
+            }
+            .sheet(isPresented: $showDocumentPicker) {
+                DocumentPickerSheet(onSelect: { document in
+                    viewModel.attachDocument(document)
+                })
             }
         }
         .onAppear {
@@ -188,10 +197,41 @@ struct ChatView: View {
         .padding(.top, 80)
     }
 
+    private var documentBadge: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "doc.text.fill")
+                .font(.caption)
+            Text(viewModel.attachedDocument?.title ?? "")
+                .font(.caption)
+                .lineLimit(1)
+            Button {
+                viewModel.detachDocument()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(.blue.opacity(0.1))
+        .clipShape(Capsule())
+        .padding(.horizontal)
+        .padding(.top, 4)
+    }
+
     // MARK: - Input Bar
 
     private var inputBar: some View {
         HStack(alignment: .bottom, spacing: 8) {
+            Button {
+                showDocumentPicker = true
+            } label: {
+                Image(systemName: "doc.badge.plus")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+
             TextField("Message", text: $inputText, axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(1...5)

--- a/HearthAI/Features/Chat/ChatViewModel.swift
+++ b/HearthAI/Features/Chat/ChatViewModel.swift
@@ -14,6 +14,9 @@ final class ChatViewModel {
     var activeConversation: Conversation?
     var modelContext: ModelContext?
 
+    // Document Q&A
+    var attachedDocument: Document?
+
     private var config = InferenceConfiguration.default
 
     var conversationConfig: InferenceConfiguration {
@@ -113,10 +116,26 @@ final class ChatViewModel {
         }
     }
 
+    // MARK: - Document Attachment
+
+    func attachDocument(_ document: Document) {
+        attachedDocument = document
+        ensureActiveConversation()
+        activeConversation?.documentId = document.id
+        try? modelContext?.save()
+    }
+
+    func detachDocument() {
+        attachedDocument = nil
+        activeConversation?.documentId = nil
+        try? modelContext?.save()
+    }
+
     // MARK: - Conversation Management
 
     func newConversation() {
         activeConversation = nil
+        attachedDocument = nil
         messages.removeAll()
         streamingText = ""
     }
@@ -127,6 +146,20 @@ final class ChatViewModel {
             .sorted { $0.createdAt < $1.createdAt }
             .map { ChatMessage(role: $0.role, content: $0.content) }
         streamingText = ""
+        loadAttachedDocument(for: conversation)
+    }
+
+    private func loadAttachedDocument(for conversation: Conversation) {
+        guard let docId = conversation.documentId,
+              let context = modelContext else {
+            attachedDocument = nil
+            return
+        }
+        var descriptor = FetchDescriptor<Document>(
+            predicate: #Predicate { $0.id == docId }
+        )
+        descriptor.fetchLimit = 1
+        attachedDocument = try? context.fetch(descriptor).first
     }
 
     func deleteConversation(_ conversation: Conversation) {
@@ -190,16 +223,65 @@ final class ChatViewModel {
     // MARK: - Prompt Building
 
     private func buildPrompt() -> String {
-        let systemPrompt = activeConversation?.systemPrompt ?? "You are a helpful assistant."
+        let basePrompt = activeConversation?.systemPrompt
+            ?? "You are a helpful assistant."
+        let documentContext = buildDocumentContext()
+        let systemPrompt = documentContext.isEmpty
+            ? basePrompt
+            : basePrompt + "\n\n" + documentContext
+
         var prompt = "<|im_start|>system\n\(systemPrompt)<|im_end|>\n"
 
         for message in messages {
             let role = message.role == .user ? "user" : "assistant"
-            prompt += "<|im_start|>\(role)\n\(message.content)<|im_end|>\n"
+            prompt += "<|im_start|>\(role)\n\(message.content)"
+            prompt += "<|im_end|>\n"
         }
 
         prompt += "<|im_start|>assistant\n"
         return prompt
+    }
+
+    private func buildDocumentContext() -> String {
+        guard let document = attachedDocument,
+              !document.chunks.isEmpty else {
+            return ""
+        }
+
+        let lastUserMessage = messages.last {
+            $0.role == .user
+        }?.content ?? ""
+
+        let contextLength = Int(
+            activeConversation?.contextLength
+                ?? Constants.defaultContextSize
+        )
+        let tokenBudget = Int(
+            Float(contextLength)
+                * Constants.documentTokenBudgetFraction
+        )
+
+        let selectedChunks = ChunkSelectorService.selectChunks(
+            query: lastUserMessage,
+            chunks: document.chunks,
+            maxTokenBudget: tokenBudget
+        )
+
+        guard !selectedChunks.isEmpty else { return "" }
+
+        let excerpts = selectedChunks
+            .sorted { $0.chunkIndex < $1.chunkIndex }
+            .map(\.content)
+            .joined(separator: "\n\n---\n\n")
+
+        return """
+        Answer based on the following document excerpts \
+        from "\(document.title)":
+
+        ---
+        \(excerpts)
+        ---
+        """
     }
 }
 

--- a/HearthAI/Features/Documents/DocumentDetailView.swift
+++ b/HearthAI/Features/Documents/DocumentDetailView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct DocumentDetailView: View {
+    let document: Document
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                metadataSection
+                textPreviewSection
+            }
+            .padding()
+        }
+        .navigationTitle(document.title)
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(role: .destructive) {
+                    showDeleteConfirmation = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete Document",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                modelContext.delete(document)
+                try? modelContext.save()
+                dismiss()
+            }
+        } message: {
+            Text("This will permanently delete the document and its chunks.")
+        }
+    }
+
+    private var metadataSection: some View {
+        GroupBox("Details") {
+            VStack(alignment: .leading, spacing: 8) {
+                metadataRow("Type", document.documentSourceType.displayName)
+                metadataRow("Size", formattedSize)
+                metadataRow("Words", "\(document.wordCount)")
+                metadataRow("Chunks", "\(document.chunkCount)")
+                if let pages = document.pageCount {
+                    metadataRow("Pages", "\(pages)")
+                }
+                metadataRow("Imported", formattedDate)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var textPreviewSection: some View {
+        GroupBox("Extracted Text") {
+            Text(document.rawText.prefix(5000))
+                .font(.body)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if document.rawText.count > 5000 {
+                Text("... (\(document.rawText.count - 5000) more characters)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func metadataRow(
+        _ label: String, _ value: String
+    ) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+        }
+        .font(.subheadline)
+    }
+
+    private var formattedSize: String {
+        ByteCountFormatter.string(
+            fromByteCount: document.fileSize, countStyle: .file
+        )
+    }
+
+    private var formattedDate: String {
+        document.importedAt.formatted(
+            date: .abbreviated, time: .shortened
+        )
+    }
+}

--- a/HearthAI/Features/Documents/DocumentImportViewModel.swift
+++ b/HearthAI/Features/Documents/DocumentImportViewModel.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftUI
+import SwiftData
+#if os(iOS) || os(visionOS)
+import PhotosUI
+#endif
+
+@MainActor
+@Observable
+final class DocumentImportViewModel {
+    var isImporting = false
+    var importError: String?
+
+    func importFile(
+        from url: URL, context: ModelContext
+    ) async {
+        isImporting = true
+        importError = nil
+
+        do {
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer { if accessing { url.stopAccessingSecurityScopedResource() } }
+
+            let sourceType = detectSourceType(url: url)
+            let result = try await TextExtractorService.extractText(
+                from: url, type: sourceType
+            )
+
+            let attrs = try? FileManager.default.attributesOfItem(
+                atPath: url.path
+            )
+            let fileSize = attrs?[.size] as? Int64 ?? 0
+
+            let document = Document(
+                title: url.deletingPathExtension().lastPathComponent,
+                sourceType: sourceType,
+                rawText: result.text,
+                fileSize: fileSize,
+                pageCount: result.pageCount
+            )
+            context.insert(document)
+
+            let chunkTexts = ChunkingService.chunk(text: result.text)
+            for (index, text) in chunkTexts.enumerated() {
+                let chunk = DocumentChunk(
+                    content: text, chunkIndex: Int32(index)
+                )
+                chunk.document = document
+                document.chunks.append(chunk)
+            }
+
+            try context.save()
+        } catch {
+            importError = error.localizedDescription
+        }
+
+        isImporting = false
+    }
+
+    #if os(iOS) || os(visionOS)
+    func importPhoto(
+        from item: PhotosPickerItem, context: ModelContext
+    ) async {
+        isImporting = true
+        importError = nil
+
+        do {
+            guard let data = try await item.loadTransferable(
+                type: Data.self
+            ) else {
+                importError = "Unable to load photo."
+                isImporting = false
+                return
+            }
+
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + ".jpg")
+            try data.write(to: tempURL)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            let result = try await TextExtractorService.extractText(
+                from: tempURL, type: .image
+            )
+
+            let document = Document(
+                title: "Scanned Document",
+                sourceType: .image,
+                rawText: result.text,
+                fileSize: Int64(data.count)
+            )
+            context.insert(document)
+
+            let chunkTexts = ChunkingService.chunk(text: result.text)
+            for (index, text) in chunkTexts.enumerated() {
+                let chunk = DocumentChunk(
+                    content: text, chunkIndex: Int32(index)
+                )
+                chunk.document = document
+                document.chunks.append(chunk)
+            }
+
+            try context.save()
+        } catch {
+            importError = error.localizedDescription
+        }
+
+        isImporting = false
+    }
+    #endif
+
+    private func detectSourceType(url: URL) -> DocumentSourceType {
+        switch url.pathExtension.lowercased() {
+        case "pdf": .pdf
+        case "png", "jpg", "jpeg", "heic", "heif", "tiff": .image
+        default: .txt
+        }
+    }
+}

--- a/HearthAI/Features/Documents/DocumentPickerSheet.swift
+++ b/HearthAI/Features/Documents/DocumentPickerSheet.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import SwiftData
+
+/// Sheet for selecting a document to attach to a chat conversation.
+struct DocumentPickerSheet: View {
+    let onSelect: (Document) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Document.importedAt, order: .reverse)
+    private var documents: [Document]
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if documents.isEmpty {
+                    ContentUnavailableView {
+                        Label(
+                            "No Documents",
+                            systemImage: "doc.text.magnifyingglass"
+                        )
+                    } description: {
+                        Text(
+                            "Import documents from the Documents "
+                            + "tab to use them in chat."
+                        )
+                    }
+                } else {
+                    List(documents) { document in
+                        Button {
+                            onSelect(document)
+                            dismiss()
+                        } label: {
+                            DocumentRow(document: document)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Attach Document")
+            #if !os(macOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/HearthAI/Features/Documents/DocumentsView.swift
+++ b/HearthAI/Features/Documents/DocumentsView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+#if os(iOS) || os(visionOS)
+import PhotosUI
+#endif
+
+struct DocumentsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Document.importedAt, order: .reverse)
+    private var documents: [Document]
+    @State private var importViewModel = DocumentImportViewModel()
+    @State private var showFileImporter = false
+    #if os(iOS) || os(visionOS)
+    @State private var showPhotoPicker = false
+    @State private var selectedPhoto: PhotosPickerItem?
+    #endif
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if documents.isEmpty {
+                    emptyState
+                } else {
+                    documentList
+                }
+            }
+            .navigationTitle("Documents")
+            #if !os(macOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    importMenu
+                }
+            }
+            .fileImporter(
+                isPresented: $showFileImporter,
+                allowedContentTypes: supportedTypes,
+                allowsMultipleSelection: false
+            ) { result in
+                handleFileImport(result)
+            }
+            .overlay {
+                if importViewModel.isImporting {
+                    importingOverlay
+                }
+            }
+            .alert(
+                "Import Error",
+                isPresented: .init(
+                    get: { importViewModel.importError != nil },
+                    set: { if !$0 { importViewModel.importError = nil } }
+                )
+            ) {
+                Button("OK") { importViewModel.importError = nil }
+            } message: {
+                if let error = importViewModel.importError {
+                    Text(error)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Documents", systemImage: "doc.text.magnifyingglass")
+        } description: {
+            Text("Import PDFs, text files, or photos to ask questions about them.")
+        } actions: {
+            Button("Import Document") {
+                showFileImporter = true
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var documentList: some View {
+        List {
+            ForEach(documents) { document in
+                NavigationLink {
+                    DocumentDetailView(document: document)
+                } label: {
+                    DocumentRow(document: document)
+                }
+            }
+            .onDelete(perform: deleteDocuments)
+        }
+    }
+
+    private var importMenu: some View {
+        Menu {
+            Button {
+                showFileImporter = true
+            } label: {
+                Label("Import File", systemImage: "doc")
+            }
+            #if os(iOS) || os(visionOS)
+            Button {
+                showPhotoPicker = true
+            } label: {
+                Label("Scan Photo (OCR)", systemImage: "camera")
+            }
+            #endif
+        } label: {
+            Label("Import", systemImage: "plus")
+        }
+        #if os(iOS) || os(visionOS)
+        .photosPicker(
+            isPresented: $showPhotoPicker,
+            selection: $selectedPhoto,
+            matching: .images
+        )
+        .onChange(of: selectedPhoto) { _, newValue in
+            if let item = newValue {
+                Task {
+                    await importViewModel.importPhoto(
+                        from: item, context: modelContext
+                    )
+                    selectedPhoto = nil
+                }
+            }
+        }
+        #endif
+    }
+
+    private var importingOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+                .ignoresSafeArea()
+            VStack(spacing: 16) {
+                ProgressView()
+                    .controlSize(.large)
+                Text("Importing document...")
+                    .font(.headline)
+            }
+            .padding(32)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+    }
+
+    private var supportedTypes: [UTType] {
+        [.pdf, .plainText, .rtf, .utf8PlainText]
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            Task {
+                await importViewModel.importFile(
+                    from: url, context: modelContext
+                )
+            }
+        case .failure(let error):
+            importViewModel.importError = error.localizedDescription
+        }
+    }
+
+    private func deleteDocuments(at offsets: IndexSet) {
+        for index in offsets {
+            modelContext.delete(documents[index])
+        }
+        try? modelContext.save()
+    }
+}
+
+struct DocumentRow: View {
+    let document: Document
+
+    var body: some View {
+        HStack {
+            Image(systemName: document.documentSourceType.systemImage)
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(document.title)
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    Text(document.documentSourceType.displayName)
+                    Text(formattedSize)
+                    Text("\(document.chunkCount) chunks")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var formattedSize: String {
+        ByteCountFormatter.string(
+            fromByteCount: document.fileSize, countStyle: .file
+        )
+    }
+}

--- a/HearthAI/Models/Conversation.swift
+++ b/HearthAI/Models/Conversation.swift
@@ -12,6 +12,7 @@ final class Conversation {
     var topP: Float
     var contextLength: Int32
     var modelId: String?
+    var documentId: UUID?
 
     @Relationship(deleteRule: .cascade, inverse: \Message.conversation)
     var messages: [Message] = []
@@ -22,7 +23,8 @@ final class Conversation {
         temperature: Float = 0.7,
         topP: Float = 0.9,
         contextLength: Int32 = 2048,
-        modelId: String? = nil
+        modelId: String? = nil,
+        documentId: UUID? = nil
     ) {
         self.id = UUID()
         self.title = title
@@ -33,5 +35,6 @@ final class Conversation {
         self.topP = topP
         self.contextLength = contextLength
         self.modelId = modelId
+        self.documentId = documentId
     }
 }

--- a/HearthAI/Models/Document.swift
+++ b/HearthAI/Models/Document.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Document {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var sourceType: String
+    var importedAt: Date
+    var rawText: String
+    var fileSize: Int64
+    var pageCount: Int32?
+
+    @Relationship(deleteRule: .cascade, inverse: \DocumentChunk.document)
+    var chunks: [DocumentChunk] = []
+
+    init(
+        title: String,
+        sourceType: DocumentSourceType = .txt,
+        rawText: String = "",
+        fileSize: Int64 = 0,
+        pageCount: Int32? = nil
+    ) {
+        self.id = UUID()
+        self.title = title
+        self.sourceType = sourceType.rawValue
+        self.importedAt = .now
+        self.rawText = rawText
+        self.fileSize = fileSize
+        self.pageCount = pageCount
+    }
+
+    var documentSourceType: DocumentSourceType {
+        DocumentSourceType(rawValue: sourceType) ?? .txt
+    }
+
+    var chunkCount: Int {
+        chunks.count
+    }
+
+    var wordCount: Int {
+        rawText.split(separator: " ").count
+    }
+}
+
+enum DocumentSourceType: String, Codable, CaseIterable {
+    case pdf
+    case txt
+    case image
+
+    var displayName: String {
+        switch self {
+        case .pdf: "PDF"
+        case .txt: "Text"
+        case .image: "Image (OCR)"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .pdf: "doc.richtext"
+        case .txt: "doc.plaintext"
+        case .image: "photo"
+        }
+    }
+}

--- a/HearthAI/Models/DocumentChunk.swift
+++ b/HearthAI/Models/DocumentChunk.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftData
+
+@Model
+final class DocumentChunk {
+    @Attribute(.unique) var id: UUID
+    var content: String
+    var chunkIndex: Int32
+    var tokenEstimate: Int32
+
+    var document: Document?
+
+    init(
+        content: String,
+        chunkIndex: Int32,
+        tokenEstimate: Int32? = nil
+    ) {
+        self.id = UUID()
+        self.content = content
+        self.chunkIndex = chunkIndex
+        self.tokenEstimate = tokenEstimate
+            ?? Int32(content.count / 4)
+    }
+}

--- a/HearthAI/Services/DocumentProcessing/ChunkSelectorService.swift
+++ b/HearthAI/Services/DocumentProcessing/ChunkSelectorService.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+enum ChunkSelectorService {
+
+    /// Selects the most relevant chunks for a query using TF-IDF
+    /// scoring. Returns chunks sorted by relevance, up to
+    /// `maxTokenBudget` total estimated tokens.
+    static func selectChunks(
+        query: String,
+        chunks: [DocumentChunk],
+        maxTokenBudget: Int
+    ) -> [DocumentChunk] {
+        guard !chunks.isEmpty, !query.isEmpty else { return [] }
+
+        let queryTerms = tokenize(query)
+        guard !queryTerms.isEmpty else {
+            // No meaningful terms — return first chunks up to budget
+            return takeWithinBudget(
+                chunks.sorted { $0.chunkIndex < $1.chunkIndex },
+                budget: maxTokenBudget
+            )
+        }
+
+        // Compute IDF for each query term across all chunks
+        let totalDocs = Double(chunks.count)
+        var idf: [String: Double] = [:]
+        for term in queryTerms {
+            let docsWithTerm = chunks.filter {
+                tokenize($0.content).contains(term)
+            }.count
+            idf[term] = log(
+                (totalDocs + 1) / (Double(docsWithTerm) + 1)
+            ) + 1
+        }
+
+        // Score each chunk
+        let scored: [(chunk: DocumentChunk, score: Double)] = chunks
+            .map { chunk in
+                let chunkTokens = tokenize(chunk.content)
+                let totalTokens = Double(chunkTokens.count)
+                guard totalTokens > 0 else {
+                    return (chunk: chunk, score: 0)
+                }
+
+                var score = 0.0
+                for term in queryTerms {
+                    let termFreq = Double(
+                        chunkTokens.filter { $0 == term }.count
+                    ) / totalTokens
+                    score += termFreq * (idf[term] ?? 1.0)
+                }
+                return (chunk: chunk, score: score)
+            }
+            .sorted { $0.score > $1.score }
+
+        return takeWithinBudget(
+            scored.map(\.chunk), budget: maxTokenBudget
+        )
+    }
+
+    // MARK: - Private
+
+    private static func tokenize(_ text: String) -> [String] {
+        text.lowercased()
+            .components(separatedBy: .alphanumerics.inverted)
+            .filter { $0.count > 2 }
+    }
+
+    private static func takeWithinBudget(
+        _ chunks: [DocumentChunk], budget: Int
+    ) -> [DocumentChunk] {
+        var result: [DocumentChunk] = []
+        var remaining = budget
+        for chunk in chunks {
+            let tokens = Int(chunk.tokenEstimate)
+            if tokens <= remaining {
+                result.append(chunk)
+                remaining -= tokens
+            } else if result.isEmpty {
+                // Always include at least one chunk
+                result.append(chunk)
+                break
+            }
+        }
+        return result
+    }
+}

--- a/HearthAI/Services/DocumentProcessing/ChunkingService.swift
+++ b/HearthAI/Services/DocumentProcessing/ChunkingService.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+enum ChunkingService {
+
+    /// Splits text into chunks of approximately `maxTokens` size
+    /// with `overlapTokens` overlap between consecutive chunks.
+    /// Token count is estimated as character count / 4.
+    static func chunk(
+        text: String,
+        maxTokens: Int = Constants.defaultChunkSize,
+        overlapTokens: Int = Constants.defaultChunkOverlap
+    ) -> [String] {
+        let trimmed = text.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !trimmed.isEmpty else { return [] }
+
+        let maxChars = maxTokens * 4
+        let overlapChars = overlapTokens * 4
+
+        // If text fits in a single chunk, return it directly
+        if trimmed.count <= maxChars {
+            return [trimmed]
+        }
+
+        let paragraphs = splitIntoParagraphs(trimmed)
+        var chunks: [String] = []
+        var currentChunk = ""
+
+        for paragraph in paragraphs {
+            let candidate = currentChunk.isEmpty
+                ? paragraph
+                : currentChunk + "\n\n" + paragraph
+
+            if candidate.count <= maxChars {
+                currentChunk = candidate
+            } else {
+                // If current chunk has content, save it
+                if !currentChunk.isEmpty {
+                    chunks.append(currentChunk)
+                    // Start next chunk with overlap from end
+                    currentChunk = overlap(
+                        from: currentChunk,
+                        chars: overlapChars
+                    ) + "\n\n" + paragraph
+                } else {
+                    // Single paragraph exceeds max — split by sentences
+                    let sentenceChunks = splitBySentences(
+                        paragraph, maxChars: maxChars,
+                        overlapChars: overlapChars
+                    )
+                    chunks.append(contentsOf: sentenceChunks.dropLast())
+                    currentChunk = sentenceChunks.last ?? ""
+                }
+            }
+        }
+
+        if !currentChunk.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty {
+            chunks.append(currentChunk)
+        }
+
+        return chunks
+    }
+
+    // MARK: - Private
+
+    private static func splitIntoParagraphs(
+        _ text: String
+    ) -> [String] {
+        text.components(separatedBy: "\n\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func overlap(
+        from text: String, chars: Int
+    ) -> String {
+        guard chars > 0, text.count > chars else { return text }
+        let start = text.index(text.endIndex, offsetBy: -chars)
+        return String(text[start...])
+    }
+
+    private static func splitBySentences(
+        _ text: String,
+        maxChars: Int,
+        overlapChars: Int
+    ) -> [String] {
+        let sentences = text.components(separatedBy: ". ")
+            .map { $0.hasSuffix(".") ? $0 : $0 + "." }
+
+        var chunks: [String] = []
+        var current = ""
+
+        for sentence in sentences {
+            let candidate = current.isEmpty
+                ? sentence
+                : current + " " + sentence
+
+            if candidate.count <= maxChars {
+                current = candidate
+            } else {
+                if !current.isEmpty {
+                    chunks.append(current)
+                    current = overlap(
+                        from: current, chars: overlapChars
+                    ) + " " + sentence
+                } else {
+                    // Single sentence exceeds max — just truncate
+                    chunks.append(
+                        String(sentence.prefix(maxChars))
+                    )
+                    current = ""
+                }
+            }
+        }
+
+        if !current.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty {
+            chunks.append(current)
+        }
+
+        return chunks
+    }
+}

--- a/HearthAI/Services/DocumentProcessing/TextExtractorService.swift
+++ b/HearthAI/Services/DocumentProcessing/TextExtractorService.swift
@@ -1,0 +1,158 @@
+import Foundation
+import PDFKit
+#if canImport(Vision)
+import Vision
+#endif
+
+struct ExtractedText {
+    let text: String
+    let pageCount: Int32?
+}
+
+enum TextExtractorService {
+
+    static func extractText(
+        from url: URL,
+        type: DocumentSourceType
+    ) async throws -> ExtractedText {
+        switch type {
+        case .pdf:
+            return try extractFromPDF(url: url)
+        case .txt:
+            return try extractFromText(url: url)
+        case .image:
+            return try await extractFromImage(url: url)
+        }
+    }
+
+    // MARK: - PDF
+
+    private static func extractFromPDF(
+        url: URL
+    ) throws -> ExtractedText {
+        guard let document = PDFDocument(url: url) else {
+            throw DocumentError.unableToReadFile(url.lastPathComponent)
+        }
+
+        var text = ""
+        let pageCount = document.pageCount
+
+        for index in 0..<pageCount {
+            if let page = document.page(at: index),
+               let pageText = page.string {
+                if !text.isEmpty { text += "\n\n" }
+                text += pageText
+            }
+        }
+
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty else {
+            throw DocumentError.noTextContent(url.lastPathComponent)
+        }
+
+        return ExtractedText(
+            text: text, pageCount: Int32(pageCount)
+        )
+    }
+
+    // MARK: - Plain Text
+
+    private static func extractFromText(
+        url: URL
+    ) throws -> ExtractedText {
+        let text = try String(contentsOf: url, encoding: .utf8)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty else {
+            throw DocumentError.noTextContent(url.lastPathComponent)
+        }
+        return ExtractedText(text: text, pageCount: nil)
+    }
+
+    // MARK: - Image (OCR)
+
+    private static func extractFromImage(
+        url: URL
+    ) async throws -> ExtractedText {
+        #if canImport(Vision)
+        let data = try Data(contentsOf: url)
+
+        #if os(macOS)
+        guard let nsImage = NSImage(data: data),
+              let cgImage = nsImage.cgImage(
+                forProposedRect: nil, context: nil, hints: nil
+              ) else {
+            throw DocumentError.unableToReadFile(url.lastPathComponent)
+        }
+        #else
+        guard let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            throw DocumentError.unableToReadFile(url.lastPathComponent)
+        }
+        #endif
+
+        let text = try await performOCR(on: cgImage)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty else {
+            throw DocumentError.noTextContent(url.lastPathComponent)
+        }
+        return ExtractedText(text: text, pageCount: nil)
+        #else
+        throw DocumentError.ocrUnavailable
+        #endif
+    }
+
+    #if canImport(Vision)
+    private static func performOCR(
+        on image: CGImage
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let request = VNRecognizeTextRequest { request, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                let observations = request.results
+                    as? [VNRecognizedTextObservation] ?? []
+                let text = observations.compactMap {
+                    $0.topCandidates(1).first?.string
+                }.joined(separator: "\n")
+
+                continuation.resume(returning: text)
+            }
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+
+            let handler = VNImageRequestHandler(
+                cgImage: image, options: [:]
+            )
+
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+    #endif
+}
+
+enum DocumentError: Error, LocalizedError {
+    case unableToReadFile(String)
+    case noTextContent(String)
+    case ocrUnavailable
+    case unsupportedFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unableToReadFile(let name):
+            "Unable to read file: \(name)"
+        case .noTextContent(let name):
+            "No text content found in: \(name)"
+        case .ocrUnavailable:
+            "OCR is not available on this platform."
+        case .unsupportedFormat(let ext):
+            "Unsupported file format: \(ext)"
+        }
+    }
+}

--- a/HearthAI/Shared/Constants.swift
+++ b/HearthAI/Shared/Constants.swift
@@ -7,4 +7,10 @@ enum Constants {
     static let defaultRepeatPenalty: Float = 1.1
     static let defaultMaxTokens: Int32 = 512
     static let backgroundUnloadTimeout: TimeInterval = 60
+
+    // Document processing
+    static let defaultChunkSize: Int = 512
+    static let defaultChunkOverlap: Int = 50
+    static let maxDocumentChunksInPrompt: Int = 3
+    static let documentTokenBudgetFraction: Float = 0.6
 }

--- a/HearthAITests/ChunkSelectorServiceTests.swift
+++ b/HearthAITests/ChunkSelectorServiceTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import HearthAI
+
+@Suite
+struct ChunkSelectorServiceTests {
+
+    private func makeChunk(
+        content: String, index: Int32
+    ) -> DocumentChunk {
+        DocumentChunk(content: content, chunkIndex: index)
+    }
+
+    @Test func emptyChunksReturnsEmpty() {
+        let result = ChunkSelectorService.selectChunks(
+            query: "test", chunks: [], maxTokenBudget: 1000
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func emptyQueryReturnsEmpty() {
+        let chunk = makeChunk(content: "Some content", index: 0)
+        let result = ChunkSelectorService.selectChunks(
+            query: "", chunks: [chunk], maxTokenBudget: 1000
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func selectsMostRelevantChunk() {
+        let chunk1 = makeChunk(
+            content: "The weather is sunny and warm today",
+            index: 0
+        )
+        let chunk2 = makeChunk(
+            content: "Swift programming language is great for iOS apps",
+            index: 1
+        )
+        let chunk3 = makeChunk(
+            content: "The temperature and weather forecast looks good",
+            index: 2
+        )
+
+        let result = ChunkSelectorService.selectChunks(
+            query: "What is the weather?",
+            chunks: [chunk1, chunk2, chunk3],
+            maxTokenBudget: 100
+        )
+
+        #expect(!result.isEmpty)
+        // Weather-related chunks should rank higher
+        let selectedContents = result.map(\.content)
+        let hasWeatherChunk = selectedContents.contains {
+            $0.contains("weather")
+        }
+        #expect(hasWeatherChunk)
+    }
+
+    @Test func respectsTokenBudget() {
+        // Each chunk has ~25 token estimate (100 chars / 4)
+        let chunks = (0..<10).map { index in
+            makeChunk(
+                content: String(
+                    repeating: "test word content here. ",
+                    count: 4
+                ),
+                index: Int32(index)
+            )
+        }
+
+        let result = ChunkSelectorService.selectChunks(
+            query: "test content",
+            chunks: chunks,
+            maxTokenBudget: 50
+        )
+
+        let totalTokens = result.reduce(0) {
+            $0 + Int($1.tokenEstimate)
+        }
+        // Should not exceed budget (except for the "always include
+        // at least one" rule)
+        #expect(
+            totalTokens <= 50
+            || (result.count == 1 && totalTokens > 0)
+        )
+    }
+
+    @Test func alwaysIncludesAtLeastOneChunk() {
+        let chunk = makeChunk(
+            content: String(repeating: "large ", count: 200),
+            index: 0
+        )
+
+        let result = ChunkSelectorService.selectChunks(
+            query: "large",
+            chunks: [chunk],
+            maxTokenBudget: 10
+        )
+
+        #expect(result.count == 1)
+    }
+
+    @Test func ranksMultipleMatchesHigher() {
+        let chunk1 = makeChunk(
+            content: "apple apple apple banana",
+            index: 0
+        )
+        let chunk2 = makeChunk(
+            content: "cherry grape lemon orange",
+            index: 1
+        )
+
+        let result = ChunkSelectorService.selectChunks(
+            query: "apple banana",
+            chunks: [chunk1, chunk2],
+            maxTokenBudget: 1000
+        )
+
+        // chunk1 should be first since it has the query terms
+        #expect(result.first?.content.contains("apple") == true)
+    }
+}

--- a/HearthAITests/ChunkingServiceTests.swift
+++ b/HearthAITests/ChunkingServiceTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import HearthAI
+
+@Suite
+struct ChunkingServiceTests {
+
+    @Test func emptyTextReturnsNoChunks() {
+        let chunks = ChunkingService.chunk(text: "")
+        #expect(chunks.isEmpty)
+    }
+
+    @Test func whitespaceOnlyReturnsNoChunks() {
+        let chunks = ChunkingService.chunk(text: "   \n\n  ")
+        #expect(chunks.isEmpty)
+    }
+
+    @Test func shortTextReturnsSingleChunk() {
+        let text = "Hello, this is a short document."
+        let chunks = ChunkingService.chunk(text: text)
+        #expect(chunks.count == 1)
+        #expect(chunks.first == text)
+    }
+
+    @Test func multiParagraphChunking() {
+        // Create text with multiple paragraphs that together exceed
+        // one chunk
+        let paragraph = String(repeating: "word ", count: 200)
+        let text = paragraph + "\n\n" + paragraph + "\n\n" + paragraph
+
+        let chunks = ChunkingService.chunk(
+            text: text, maxTokens: 300, overlapTokens: 20
+        )
+
+        #expect(chunks.count >= 2)
+        // Verify all chunks are non-empty
+        for chunk in chunks {
+            #expect(!chunk.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty)
+        }
+    }
+
+    @Test func chunksHaveOverlap() {
+        let para1 = String(repeating: "alpha ", count: 150)
+        let para2 = String(repeating: "beta ", count: 150)
+        let text = para1 + "\n\n" + para2
+
+        let chunks = ChunkingService.chunk(
+            text: text, maxTokens: 200, overlapTokens: 30
+        )
+
+        #expect(chunks.count >= 2)
+        // The end of the first chunk should appear at the start
+        // of the second
+        if chunks.count >= 2 {
+            let firstEnd = String(chunks[0].suffix(100))
+            let words = firstEnd.split(separator: " ")
+            if let lastWord = words.last {
+                #expect(chunks[1].contains(String(lastWord)))
+            }
+        }
+    }
+
+    @Test func singleLongParagraphGetsSplit() {
+        // One huge paragraph with no double newlines
+        let text = String(repeating: "test sentence. ", count: 500)
+
+        let chunks = ChunkingService.chunk(
+            text: text, maxTokens: 200, overlapTokens: 20
+        )
+
+        #expect(chunks.count >= 2)
+    }
+
+    @Test func customMaxTokensRespected() {
+        let text = String(repeating: "hello ", count: 300)
+        let maxTokens = 100
+        let maxChars = maxTokens * 4
+
+        let chunks = ChunkingService.chunk(
+            text: text, maxTokens: maxTokens, overlapTokens: 10
+        )
+
+        // Each chunk should be roughly within the max size
+        // (with some tolerance for sentence boundaries)
+        for chunk in chunks {
+            #expect(chunk.count <= maxChars * 2)
+        }
+    }
+
+    @Test func preservesParagraphBoundaries() {
+        let text = "First paragraph.\n\nSecond paragraph.\n\nThird."
+        let chunks = ChunkingService.chunk(
+            text: text, maxTokens: 500, overlapTokens: 10
+        )
+
+        #expect(chunks.count == 1)
+        #expect(chunks.first?.contains("First paragraph.") == true)
+        #expect(chunks.first?.contains("Second paragraph.") == true)
+        #expect(chunks.first?.contains("Third.") == true)
+    }
+}

--- a/HearthAITests/DocumentModelTests.swift
+++ b/HearthAITests/DocumentModelTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import HearthAI
+
+@Suite(.serialized)
+@MainActor
+struct DocumentModelTests {
+
+    // MARK: - Document Creation
+
+    @Test func documentDefaultValues() {
+        let doc = Document(title: "Test Doc")
+        #expect(doc.title == "Test Doc")
+        #expect(doc.documentSourceType == .txt)
+        #expect(doc.rawText.isEmpty)
+        #expect(doc.fileSize == 0)
+        #expect(doc.pageCount == nil)
+        #expect(doc.chunks.isEmpty)
+    }
+
+    @Test func documentCustomValues() {
+        let doc = Document(
+            title: "My PDF",
+            sourceType: .pdf,
+            rawText: "Hello world",
+            fileSize: 1024,
+            pageCount: 5
+        )
+        #expect(doc.title == "My PDF")
+        #expect(doc.documentSourceType == .pdf)
+        #expect(doc.rawText == "Hello world")
+        #expect(doc.fileSize == 1024)
+        #expect(doc.pageCount == 5)
+    }
+
+    @Test func documentWordCount() {
+        let doc = Document(
+            title: "Test",
+            rawText: "one two three four five"
+        )
+        #expect(doc.wordCount == 5)
+    }
+
+    // MARK: - DocumentChunk Creation
+
+    @Test func chunkTokenEstimate() {
+        let chunk = DocumentChunk(
+            content: String(repeating: "a", count: 100),
+            chunkIndex: 0
+        )
+        #expect(chunk.tokenEstimate == 25) // 100 / 4
+    }
+
+    @Test func chunkCustomTokenEstimate() {
+        let chunk = DocumentChunk(
+            content: "hello", chunkIndex: 0, tokenEstimate: 42
+        )
+        #expect(chunk.tokenEstimate == 42)
+    }
+
+    // MARK: - DocumentSourceType
+
+    @Test func sourceTypeDisplayNames() {
+        #expect(DocumentSourceType.pdf.displayName == "PDF")
+        #expect(DocumentSourceType.txt.displayName == "Text")
+        #expect(DocumentSourceType.image.displayName == "Image (OCR)")
+    }
+
+    @Test func sourceTypeSystemImages() {
+        #expect(!DocumentSourceType.pdf.systemImage.isEmpty)
+        #expect(!DocumentSourceType.txt.systemImage.isEmpty)
+        #expect(!DocumentSourceType.image.systemImage.isEmpty)
+    }
+
+    // MARK: - SwiftData Persistence
+
+    @Test func documentPersistsWithChunks() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
+
+        let doc = Document(
+            title: "Persisted Doc",
+            rawText: "Some text"
+        )
+        context.insert(doc)
+
+        let chunk1 = DocumentChunk(content: "chunk one", chunkIndex: 0)
+        chunk1.document = doc
+        doc.chunks.append(chunk1)
+
+        let chunk2 = DocumentChunk(content: "chunk two", chunkIndex: 1)
+        chunk2.document = doc
+        doc.chunks.append(chunk2)
+
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Document>())
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.chunks.count == 2)
+        #expect(fetched.first?.chunkCount == 2)
+    }
+
+    @Test func deletingDocumentCascadesToChunks() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
+
+        let doc = Document(title: "To Delete")
+        context.insert(doc)
+
+        let chunk = DocumentChunk(content: "data", chunkIndex: 0)
+        chunk.document = doc
+        doc.chunks.append(chunk)
+        try context.save()
+
+        let chunksBefore = try context.fetch(
+            FetchDescriptor<DocumentChunk>()
+        )
+        #expect(chunksBefore.count == 1)
+
+        context.delete(doc)
+        try context.save()
+
+        let docs = try context.fetch(FetchDescriptor<Document>())
+        #expect(docs.isEmpty)
+
+        let chunksAfter = try context.fetch(
+            FetchDescriptor<DocumentChunk>()
+        )
+        for chunk in chunksAfter {
+            #expect(chunk.document == nil)
+        }
+    }
+
+    // MARK: - Conversation Document Reference
+
+    @Test func conversationDocumentId() throws {
+        let context = try TestModelContainer.makeContext()
+        try TestModelContainer.cleanUp(context)
+
+        let docId = UUID()
+        let conversation = Conversation(
+            title: "Doc Chat", documentId: docId
+        )
+        context.insert(conversation)
+        try context.save()
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Conversation>()
+        )
+        #expect(fetched.first?.documentId == docId)
+    }
+
+    @Test func conversationDocumentIdDefaultsNil() {
+        let conversation = Conversation(title: "Normal Chat")
+        #expect(conversation.documentId == nil)
+    }
+
+    // MARK: - DocumentError
+
+    @Test func documentErrorDescriptions() {
+        let err1 = DocumentError.unableToReadFile("test.pdf")
+        #expect(err1.errorDescription?.contains("test.pdf") == true)
+
+        let err2 = DocumentError.noTextContent("empty.pdf")
+        #expect(err2.errorDescription?.contains("empty.pdf") == true)
+
+        let err3 = DocumentError.ocrUnavailable
+        #expect(err3.errorDescription?.contains("OCR") == true)
+
+        let err4 = DocumentError.unsupportedFormat("xyz")
+        #expect(err4.errorDescription?.contains("xyz") == true)
+    }
+}

--- a/HearthAITests/TestModelContainer.swift
+++ b/HearthAITests/TestModelContainer.swift
@@ -14,6 +14,7 @@ enum TestModelContainer {
             let config = ModelConfiguration(isStoredInMemoryOnly: true)
             let container = try ModelContainer(
                 for: Conversation.self, Message.self, LocalModel.self,
+                Document.self, DocumentChunk.self,
                 configurations: config
             )
             _container = container
@@ -26,6 +27,8 @@ enum TestModelContainer {
     }
 
     static func cleanUp(_ context: ModelContext) throws {
+        try context.fetch(FetchDescriptor<DocumentChunk>()).forEach { context.delete($0) }
+        try context.fetch(FetchDescriptor<Document>()).forEach { context.delete($0) }
         try context.fetch(FetchDescriptor<Message>()).forEach { context.delete($0) }
         try context.fetch(FetchDescriptor<Conversation>()).forEach { context.delete($0) }
         try context.fetch(FetchDescriptor<LocalModel>()).forEach { context.delete($0) }


### PR DESCRIPTION
## Summary

Closes #31

Implements v1 of Document Import & Local Q&A — users can import PDFs, text files, or photos (via OCR) and ask questions about them conversationally using on-device LLM inference. All processing stays fully local and offline.

- **Document models**: `Document` and `DocumentChunk` SwiftData models with cascade delete
- **Text extraction**: PDF via PDFKit, plain text, and images via Vision framework OCR (`VNRecognizeTextRequest`)
- **Chunking**: Paragraph-boundary splitting with configurable overlap, sentence-level fallback for long paragraphs
- **Chunk selection**: TF-IDF keyword scoring to select the most relevant chunks for each query within a token budget
- **Chat integration**: `ChatViewModel.buildPrompt()` injects relevant document excerpts into the system prompt based on the user's message
- **Documents tab**: Full document management UI with import, detail view, and storage info
- **Chat attachment**: Document picker sheet, attachment badge in chat input bar, persistent linking via `Conversation.documentId`
- **22 new tests** covering chunking logic, TF-IDF selection, document models, cascade delete, and error handling

## Design Decisions

- v1 uses TF-IDF keyword matching (no embeddings) — simple, offline, no extra model needed
- Document chunks are pre-computed and stored in SwiftData to avoid re-processing
- Document context injected into system prompt section (not as fake conversation turns) for clean ChatML formatting
- `documentId` on Conversation is a loose UUID reference, not a SwiftData relationship — documents outlive conversations
- Photo OCR uses `.accurate` recognition level with language correction

## Test Plan

- [x] All tests pass on iOS Simulator (6 suites)
- [x] All tests pass on macOS (6 suites)
- [x] Zero SwiftLint violations (64 files)
- [x] Both iOS and macOS builds succeed
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)