### PR TITLE
Fix: Allow keyboard dismiss in chat view

### DIFF
--- a/HearthAI/Features/Chat/ChatView.swift
+++ b/HearthAI/Features/Chat/ChatView.swift
@@ -167,6 +167,7 @@ struct ChatView: View {
                 }
                 .padding()
             }
+            .scrollDismissesKeyboard(.interactively)
             .onChange(of: viewModel.streamingText) {
                 withAnimation(.easeOut(duration: 0.1)) {
                     proxy.scrollTo("streaming", anchor: .bottom)


### PR DESCRIPTION
## Summary
- Added `.scrollDismissesKeyboard(.interactively)` to the chat message `ScrollView`
- Users can now swipe down on the message list to dismiss the keyboard and access tab bar navigation
- Uses the interactive mode so the keyboard follows the user's finger while scrolling

## Test plan
- [ ] Open a chat conversation on iOS
- [ ] Tap the message input to bring up the keyboard
- [ ] Swipe down on the message list and verify the keyboard dismisses interactively
- [ ] Confirm the tab bar / menu navigation is accessible after dismissing the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)