### PR TITLE
Bump version to 1.0.1 (build 2)

### DIFF
--- a/HearthAI.xcodeproj/project.pbxproj
+++ b/HearthAI.xcodeproj/project.pbxproj
@@ -781,7 +781,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "HearthAI ShareExtension/HearthAIShareExtension.entitlements";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "HearthAI ShareExtension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -789,7 +789,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI.ShareExtension;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -957,7 +957,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "HearthAI ShareExtension/HearthAIShareExtension.entitlements";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "HearthAI ShareExtension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -965,7 +965,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI.ShareExtension;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -984,7 +984,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HearthAI/HearthAI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HearthAI/Info.plist;
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";
@@ -1017,7 +1017,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HearthAI/HearthAI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HearthAI/Info.plist;
@@ -1031,7 +1031,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.hearth.HearthAI;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator macosx";

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         ENABLE_PREVIEWS: true
         CODE_SIGN_ENTITLEMENTS: HearthAI/HearthAI.entitlements
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "1"
+        MARKETING_VERSION: "1.0.1"
+        CURRENT_PROJECT_VERSION: "2"
     dependencies:
       - package: LlamaCpp
       - target: HearthAIShareExtension
@@ -76,8 +76,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: ai.hearth.HearthAI.ShareExtension
         SKIP_INSTALL: true
         GENERATE_INFOPLIST_FILE: true
-        MARKETING_VERSION: "1.0"
-        CURRENT_PROJECT_VERSION: "1"
+        MARKETING_VERSION: "1.0.1"
+        CURRENT_PROJECT_VERSION: "2"
 
   HearthAITests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from `1.0` to `1.0.1` (both HearthAI and ShareExtension targets)
- Bump `CURRENT_PROJECT_VERSION` from `1` to `2`

Prepares for App Store resubmission after fixing macOS rejection (Guideline 2.1(a)).

## Test plan

- [ ] Verify version shows as 1.0.1 in Settings > About
- [ ] Verify build number is 2 in Xcode archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)